### PR TITLE
Adding buddybuild status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 #Swift Radio
 
+[![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=56579c1328898101003ae8f3&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/56579c1328898101003ae8f3/build/latest)
+
 Swift Radio is an open source radio station app with robust and professional features. This is a fully realized Radio App built entirely in Swift 2.
 
 ![alt text](http://matthewfecher.com/wp-content/uploads/2015/09/screen-1.jpg "Swift Radio")


### PR DESCRIPTION
Hi Matthew! 

We really liked Swift-Radio-Pro and wanted to offer you a free continuous integration system [(buddybuild)](http://buddybuild.com) to make sure that your app always works!

If this sounds like something that may be helpful, setup is really simple and we've already taken most of the steps for you…[here](https://dashboard.buddybuild.com/apps/56579c1328898101003ae8f3/build/latest) are the builds we've completed for Swift-Radio-Pro so far.

![screen shot 2015-11-26 at 4 05 10 pm](https://cloud.githubusercontent.com/assets/13876667/11431951/aa1ac9e4-9457-11e5-87fa-bf7fee1667a2.png)

To configure your builds and to to make sure we kick off a new build with every commit you make, simply login [here] (https://dashboard.buddybuild.com).

Finally, if you’d like to know the latest build status of your app directly from your repo page, we offer small status badges - like the one seen on the [flappyswift](https://github.com/fullstackio/FlappySwift) repo.

To help add these, we created this pull request by adding a couple of lines to the readme.

If you have any questions or would like to learn more about buddybuild, feel free to email team@buddybuild.com directly or use the Intercom button on the website.