### PR TITLE
Removes redundant addition of adding the block to run on the background thread

### DIFF
--- a/SwiftRadio/DataManager.swift
+++ b/SwiftRadio/DataManager.swift
@@ -37,16 +37,16 @@ class DataManager {
     
     class func getDataFromFileWithSuccess(success: (data: NSData) -> Void) {
         
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
-            
-            let filePath = NSBundle.mainBundle().pathForResource("stations", ofType:"json")
+        if let filePath = NSBundle.mainBundle().pathForResource("stations", ofType:"json") {
             do {
-                let data = try NSData(contentsOfFile:filePath!,
+                let data = try NSData(contentsOfFile:filePath,
                     options: NSDataReadingOptions.DataReadingUncached)
                 success(data: data)
             } catch {
                 fatalError()
             }
+        } else {
+            print("The local JSON file could not be found")
         }
     }
     

--- a/SwiftRadio/StationsViewController.swift
+++ b/SwiftRadio/StationsViewController.swift
@@ -121,7 +121,7 @@ class StationsViewController: UIViewController {
     
     func setupPullToRefresh() {
         self.refreshControl = UIRefreshControl()
-        self.refreshControl.attributedTitle = NSAttributedString(string: "Pull to refresh")
+        self.refreshControl.attributedTitle = NSAttributedString(string: "Pull to refresh", attributes: [NSForegroundColorAttributeName:UIColor.whiteColor()])
         self.refreshControl.backgroundColor = UIColor.blackColor()
         self.refreshControl.tintColor = UIColor.whiteColor()
         self.refreshControl.addTarget(self, action: "refresh:", forControlEvents: UIControlEvents.ValueChanged)


### PR DESCRIPTION
The `getDataFromFileWithSuccess` function is already being called and executed from a background thread. Therefore it is an overhead to add the code inside the function to the same queue again.