### PR TITLE
updated addTarget selectors to the new Swift2.2 #selector syntax

### DIFF
--- a/SwiftRadio/Libraries/Spring/KeyboardLayoutConstraint.swift
+++ b/SwiftRadio/Libraries/Spring/KeyboardLayoutConstraint.swift
@@ -32,7 +32,7 @@ public class KeyboardLayoutConstraint: NSLayoutConstraint {
 
         offset = constant
 
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "keyboardWillShowNotification:", name: UIKeyboardWillShowNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(KeyboardLayoutConstraint.keyboardWillShowNotification(_:)), name: UIKeyboardWillShowNotification, object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "keyboardWillHideNotification:", name: UIKeyboardWillHideNotification, object: nil)
     }
 

--- a/SwiftRadio/Libraries/Spring/Spring.swift
+++ b/SwiftRadio/Libraries/Spring/Spring.swift
@@ -65,7 +65,7 @@ public class Spring : NSObject {
     }
 
     func commonInit() {
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "didBecomeActiveNotification:", name: UIApplicationDidBecomeActiveNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(Spring.didBecomeActiveNotification(_:)), name: UIApplicationDidBecomeActiveNotification, object: nil)
     }
 
     func didBecomeActiveNotification(notification: NSNotification) {

--- a/SwiftRadio/NowPlayingViewController.swift
+++ b/SwiftRadio/NowPlayingViewController.swift
@@ -75,13 +75,13 @@ class NowPlayingViewController: UIViewController {
         
         // Notification for when app becomes active
         NSNotificationCenter.defaultCenter().addObserver(self,
-            selector: "didBecomeActiveNotificationReceived",
+            selector: #selector(NowPlayingViewController.didBecomeActiveNotificationReceived),
             name:"UIApplicationDidBecomeActiveNotification",
             object: nil)
         
         // Notification for MediaPlayer metadata updated
         NSNotificationCenter.defaultCenter().addObserver(self,
-            selector: Selector("metadataUpdated:"),
+            selector: #selector(NowPlayingViewController.metadataUpdated(_:)),
             name:MPMoviePlayerTimedMetadataUpdatedNotification,
             object: nil);
         

--- a/SwiftRadio/PopUpMenuViewController.swift
+++ b/SwiftRadio/PopUpMenuViewController.swift
@@ -32,7 +32,7 @@ class PopUpMenuViewController: UIViewController {
         view.backgroundColor = UIColor.clearColor()
         
         // Add gesture recognizer to dismiss view when touched
-        let gestureRecognizer = UITapGestureRecognizer(target: self, action: Selector("closeButtonPressed"))
+        let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(PopUpMenuViewController.closeButtonPressed))
         backgroundView.userInteractionEnabled = true
         backgroundView.addGestureRecognizer(gestureRecognizer)
     }

--- a/SwiftRadio/StationsViewController.swift
+++ b/SwiftRadio/StationsViewController.swift
@@ -124,7 +124,7 @@ class StationsViewController: UIViewController {
         self.refreshControl.attributedTitle = NSAttributedString(string: "Pull to refresh", attributes: [NSForegroundColorAttributeName:UIColor.whiteColor()])
         self.refreshControl.backgroundColor = UIColor.blackColor()
         self.refreshControl.tintColor = UIColor.whiteColor()
-        self.refreshControl.addTarget(self, action: "refresh:", forControlEvents: UIControlEvents.ValueChanged)
+        self.refreshControl.addTarget(self, action: #selector(StationsViewController.refresh(_:)), forControlEvents: UIControlEvents.ValueChanged)
         self.tableView.addSubview(refreshControl)
     }
     
@@ -135,7 +135,7 @@ class StationsViewController: UIViewController {
     
     func createNowPlayingBarButton() {
         if self.navigationItem.rightBarButtonItem == nil {
-            let btn = UIBarButtonItem(title: "", style: UIBarButtonItemStyle.Plain, target: self, action:"nowPlayingBarButtonPressed")
+            let btn = UIBarButtonItem(title: "", style: UIBarButtonItemStyle.Plain, target: self, action:#selector(StationsViewController.nowPlayingBarButtonPressed))
             btn.image = UIImage(named: "btn-nowPlaying")
             self.navigationItem.rightBarButtonItem = btn
         }


### PR DESCRIPTION
Swift 2.2 update gave us a new syntax for the addTarget(selector...) methods and ensures type safety by utilizing a #selector(...) style which verifies existence of targeted methods in a pre runtime environment. 

I've made the appropriate updates and will attach this PR to a new issue for your consideration.

Thank you.