### PR TITLE
Fixed Bluetooth

### DIFF
--- a/SwiftRadio/StationsViewController.swift
+++ b/SwiftRadio/StationsViewController.swift
@@ -56,11 +56,7 @@ class StationsViewController: UIViewController {
         var error: NSError?
         var success: Bool
         do {
-            try AVAudioSession.sharedInstance().setCategory(
-                AVAudioSessionCategoryPlayAndRecord,
-                withOptions: [
-                    AVAudioSessionCategoryOptions.DefaultToSpeaker,
-                    AVAudioSessionCategoryOptions.AllowBluetooth])
+            try audioSession.setCategory(AVAudioSessionCategoryPlayback)
             success = true
         } catch let error1 as NSError {
             error = error1

--- a/SwiftRadio/StationsViewController.swift
+++ b/SwiftRadio/StationsViewController.swift
@@ -56,7 +56,7 @@ class StationsViewController: UIViewController {
         var error: NSError?
         var success: Bool
         do {
-            try audioSession.setCategory(AVAudioSessionCategoryPlayback)
+            try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayback)
             success = true
         } catch let error1 as NSError {
             error = error1


### PR DESCRIPTION
Setting the category to "AVAudioSessionCategoryPlayback" better handles bluetooth. "AVAudioSessionCategoryPlayAndRecord" is not needed since we are only playing audio and not recording it.