### PR TITLE
Swift 3 conversion and issues fixed

### DIFF
--- a/SwiftRadio.xcodeproj/project.pbxproj
+++ b/SwiftRadio.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		94DB0AAC1B98B762005ED993 /* UnwindSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94DB0A8F1B98B762005ED993 /* UnwindSegue.swift */; };
 		94E9761C1B1A8F3200F52B1E /* UIImage+DropShadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E9761B1B1A8F3200F52B1E /* UIImage+DropShadow.swift */; };
 		94ECF2671B94D80600D120A8 /* SwiftyJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94ECF2661B94D80600D120A8 /* SwiftyJSON.swift */; };
+		C6BB97EB1E0B515600282D80 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6BB97EA1E0B515600282D80 /* Extensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -128,6 +129,7 @@
 		94E9761B1B1A8F3200F52B1E /* UIImage+DropShadow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+DropShadow.swift"; sourceTree = "<group>"; };
 		94ECF2661B94D80600D120A8 /* SwiftyJSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftyJSON.swift; path = SwiftRadio/Libraries/SwiftyJSON.swift; sourceTree = SOURCE_ROOT; };
 		B90086461BBE40AF00E5372C /* MediaPlayer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MediaPlayer.framework; path = System/Library/Frameworks/MediaPlayer.framework; sourceTree = SDKROOT; };
+		C6BB97EA1E0B515600282D80 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -186,6 +188,7 @@
 				94E976191B1A8BFB00F52B1E /* Model */,
 				94AC70AF1AD05C7400652982 /* Networking */,
 				9409E11B1ABF6FEA00312E2B /* AppDelegate.swift */,
+				C6BB97EA1E0B515600282D80 /* Extensions.swift */,
 				9409E1221ABF6FEA00312E2B /* Main.storyboard */,
 				9409E1251ABF6FEA00312E2B /* Images.xcassets */,
 				9409E1191ABF6FEA00312E2B /* Supporting Files */,
@@ -355,16 +358,18 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = CodeMarket.io;
 				TargetAttributes = {
 					2C5545B91C1124DE00728469 = {
 						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 0820;
 						TestTargetID = 9409E1151ABF6FEA00312E2B;
 					};
 					9409E1151ABF6FEA00312E2B = {
 						CreatedOnToolsVersion = 6.2;
-						LastSwiftMigration = 0800;
+						DevelopmentTeam = CMG7DVJK3J;
+						LastSwiftMigration = 0820;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
 								enabled = 1;
@@ -438,6 +443,7 @@
 				94DB0A981B98B762005ED993 /* DesignableTextField.swift in Sources */,
 				94D260911B45D20000DE671C /* SwiftRadio-Settings.swift in Sources */,
 				94DB0A941B98B762005ED993 /* DesignableButton.swift in Sources */,
+				C6BB97EB1E0B515600282D80 /* Extensions.swift in Sources */,
 				94DB0AA61B98B762005ED993 /* SpringLabel.swift in Sources */,
 				94DB0A901B98B762005ED993 /* AsyncButton.swift in Sources */,
 				94D30EA71AD07A880024FE96 /* StationTableViewCell.swift in Sources */,
@@ -507,6 +513,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = jonah.SwiftRadioUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_TARGET_NAME = SwiftRadio;
 				USES_XCTRUNNER = YES;
 			};
@@ -522,6 +529,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = jonah.SwiftRadioUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_TARGET_NAME = SwiftRadio;
 				USES_XCTRUNNER = YES;
 			};
@@ -540,8 +548,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -550,6 +560,7 @@
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -562,7 +573,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -583,8 +594,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -592,15 +605,17 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -613,6 +628,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = CMG7DVJK3J;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/SwiftRadio",
@@ -624,7 +640,7 @@
 				PRODUCT_NAME = SwiftRadio;
 				PROVISIONING_PROFILE = "";
 				SWIFT_INSTALL_OBJC_HEADER = NO;
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -636,6 +652,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = CMG7DVJK3J;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/SwiftRadio",
@@ -647,7 +664,7 @@
 				PRODUCT_NAME = SwiftRadio;
 				PROVISIONING_PROFILE = "";
 				SWIFT_INSTALL_OBJC_HEADER = NO;
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/SwiftRadio.xcodeproj/project.pbxproj
+++ b/SwiftRadio.xcodeproj/project.pbxproj
@@ -162,9 +162,8 @@
 		9409E10D1ABF6FE900312E2B = {
 			isa = PBXGroup;
 			children = (
-				B90086461BBE40AF00E5372C /* MediaPlayer.framework */,
-				9409E1181ABF6FEA00312E2B /* SwiftRadio */,
 				949BBB411ACCA2B6005B7C26 /* Libraries */,
+				9409E1181ABF6FEA00312E2B /* SwiftRadio */,
 				2C5545BB1C1124DE00728469 /* SwiftRadioUITests */,
 				9409E1171ABF6FEA00312E2B /* Products */,
 			);
@@ -182,17 +181,17 @@
 		9409E1181ABF6FEA00312E2B /* SwiftRadio */ = {
 			isa = PBXGroup;
 			children = (
-				94D2608E1B45D0F800DE671C /* ViewControllers */,
-				94D2608F1B45D11800DE671C /* Cells */,
-				94823F861B5576F4004EC711 /* Data */,
+				94D260941B45E0BA00DE671C /* UI Helpers */,
 				94E976191B1A8BFB00F52B1E /* Model */,
+				94823F861B5576F4004EC711 /* Data */,
 				94AC70AF1AD05C7400652982 /* Networking */,
+				94D2608F1B45D11800DE671C /* Cells */,
+				94D2608E1B45D0F800DE671C /* ViewControllers */,
 				9409E11B1ABF6FEA00312E2B /* AppDelegate.swift */,
 				C6BB97EA1E0B515600282D80 /* Extensions.swift */,
 				9409E1221ABF6FEA00312E2B /* Main.storyboard */,
 				9409E1251ABF6FEA00312E2B /* Images.xcassets */,
 				9409E1191ABF6FEA00312E2B /* Supporting Files */,
-				94D260941B45E0BA00DE671C /* UI Helpers */,
 			);
 			path = SwiftRadio;
 			sourceTree = "<group>";
@@ -200,6 +199,7 @@
 		9409E1191ABF6FEA00312E2B /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				B90086461BBE40AF00E5372C /* MediaPlayer.framework */,
 				9409E11A1ABF6FEA00312E2B /* Info.plist */,
 				94D260901B45D20000DE671C /* SwiftRadio-Settings.swift */,
 			);
@@ -235,11 +235,11 @@
 		94D2608E1B45D0F800DE671C /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
-				94452E541AD7086800BFE7A5 /* AboutViewController.swift */,
-				94D1D0A41AD6D6230022CA11 /* InfoDetailViewController.swift */,
-				9409E13F1ABF78B000312E2B /* NowPlayingViewController.swift */,
-				94452E4E1AD6F24700BFE7A5 /* PopUpMenuViewController.swift */,
 				942A3F361AE43DF80011396E /* StationsViewController.swift */,
+				94452E541AD7086800BFE7A5 /* AboutViewController.swift */,
+				9409E13F1ABF78B000312E2B /* NowPlayingViewController.swift */,
+				94D1D0A41AD6D6230022CA11 /* InfoDetailViewController.swift */,
+				94452E4E1AD6F24700BFE7A5 /* PopUpMenuViewController.swift */,
 			);
 			name = ViewControllers;
 			sourceTree = "<group>";
@@ -578,6 +578,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -616,6 +617,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/SwiftRadio.xcodeproj/xcshareddata/xcschemes/SwiftRadio.xcscheme
+++ b/SwiftRadio.xcodeproj/xcshareddata/xcschemes/SwiftRadio.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftRadio/AboutViewController.swift
+++ b/SwiftRadio/AboutViewController.swift
@@ -23,7 +23,7 @@ class AboutViewController: UIViewController {
     // MARK: - IBActions
     //*****************************************************************
     
-    @IBAction func emailButtonDidTouch(sender: UIButton) {
+    @IBAction func emailButtonDidTouch(_ sender: UIButton) {
         
         // Use your own email address & subject
         let receipients = ["matthew.fecher@gmail.com"]
@@ -33,17 +33,17 @@ class AboutViewController: UIViewController {
         let configuredMailComposeViewController = configureMailComposeViewController(receipients, subject: subject, messageBody: messageBody)
         
         if canSendMail() {
-            self.presentViewController(configuredMailComposeViewController, animated: true, completion: nil)
+            self.present(configuredMailComposeViewController, animated: true, completion: nil)
         } else {
             showSendMailErrorAlert()
         }
     }
     
-    @IBAction func websiteButtonDidTouch(sender: UIButton) {
+    @IBAction func websiteButtonDidTouch(_ sender: UIButton) {
         
         // Use your own website here
-        if let url = NSURL(string: "http://matthewfecher.com") {
-            UIApplication.sharedApplication().openURL(url)
+        if let url = URL(string: "http://matthewfecher.com") {
+            UIApplication.shared.openURL(url)
         }
     }
 
@@ -55,15 +55,15 @@ class AboutViewController: UIViewController {
 
 extension AboutViewController: MFMailComposeViewControllerDelegate {
     
-    func mailComposeController(controller: MFMailComposeViewController, didFinishWithResult result: MFMailComposeResult, error: NSError?) {
-        controller.dismissViewControllerAnimated(true, completion: nil)
+    func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
+        controller.dismiss(animated: true, completion: nil)
     }
     
     func canSendMail() -> Bool {
         return MFMailComposeViewController.canSendMail()
     }
     
-    func configureMailComposeViewController(recepients: [String], subject: String, messageBody: String) -> MFMailComposeViewController {
+    func configureMailComposeViewController(_ recepients: [String], subject: String, messageBody: String) -> MFMailComposeViewController {
         
         let mailComposerVC = MFMailComposeViewController()
         mailComposerVC.mailComposeDelegate = self

--- a/SwiftRadio/AnimationFrames.swift
+++ b/SwiftRadio/AnimationFrames.swift
@@ -20,7 +20,7 @@ class AnimationFrames {
             }
         }
         
-        for i in 2.stride(to: 0, by: -1) {
+        for i in stride(from: 2, to: 0, by: -1) {
             if let image = UIImage(named: "NowPlayingBars-\(i)") {
                 animationFrames.append(image)
             }

--- a/SwiftRadio/AppDelegate.swift
+++ b/SwiftRadio/AppDelegate.swift
@@ -13,46 +13,46 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         
         // MPNowPlayingInfoCenter
-        UIApplication.sharedApplication().beginReceivingRemoteControlEvents()
+        UIApplication.shared.beginReceivingRemoteControlEvents()
         
         // Make status bar white
-        UINavigationBar.appearance().barStyle = .Black
+        UINavigationBar.appearance().barStyle = .black
         
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
        
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
   
         
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
         
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
         
         
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
         // Saves changes in the application's managed object context before the application terminates.
         
-        UIApplication.sharedApplication().endReceivingRemoteControlEvents()
+        UIApplication.shared.endReceivingRemoteControlEvents()
         
     }
 

--- a/SwiftRadio/Base.lproj/Main.storyboard
+++ b/SwiftRadio/Base.lproj/Main.storyboard
@@ -1,9 +1,13 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="kdl-ej-Zz5">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="kdl-ej-Zz5">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Swift Radio-->
@@ -15,41 +19,44 @@
                         <viewControllerLayoutGuide type="bottom" id="XnL-lx-4Ua"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="OvF-E7-hdu">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="background" translatesAutoresizingMaskIntoConstraints="NO" id="g23-m5-5pm">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                             </imageView>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="dhg-xW-Q3M">
-                                <rect key="frame" x="0.0" y="64" width="320" height="460"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <rect key="frame" x="0.0" y="64" width="375" height="559"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <prototypes>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="StationCell" rowHeight="88" id="hMr-La-1Ga" customClass="StationTableViewCell" customModule="SwiftRadio" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="22" width="320" height="88"/>
+                                        <rect key="frame" x="0.0" y="22" width="375" height="88"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="hMr-La-1Ga" id="NhW-Qy-GCO">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="87"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="87"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="stationImage" translatesAutoresizingMaskIntoConstraints="NO" id="GQm-Mf-6pw">
                                                     <rect key="frame" x="8" y="9" width="110" height="70"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Station Name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="hQQ-6f-sYl">
                                                     <rect key="frame" x="132" y="20" width="180" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" name="AvenirNext-Medium" family="Avenir Next" pointSize="18"/>
-                                                    <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Desc" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ptr-mN-34N">
                                                     <rect key="frame" x="132" y="47" width="180" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="16"/>
-                                                    <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                         </tableViewCellContentView>
-                                        <color key="backgroundColor" red="0.15686274509803921" green="0.15686274509803921" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="backgroundColor" red="0.1175440177321434" green="0.11671449244022369" blue="0.14129963517189026" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <connections>
                                             <outlet property="stationDescLabel" destination="Ptr-mN-34N" id="mGP-95-uEF"/>
                                             <outlet property="stationImageView" destination="GQm-Mf-6pw" id="kCR-0m-tHf"/>
@@ -63,18 +70,18 @@
                                 </connections>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="y05-35-5xn">
-                                <rect key="frame" x="0.0" y="524" width="320" height="44"/>
+                                <rect key="frame" x="0.0" y="623" width="375" height="44"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LhZ-Go-zL7" userLabel="Now Playing Button">
-                                        <rect key="frame" x="39" y="8" width="273" height="32"/>
+                                        <rect key="frame" x="39" y="8" width="328" height="32"/>
                                         <accessibility key="accessibilityConfiguration" identifier="nowPlaying"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="32" id="3VJ-3d-FUc"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="16"/>
-                                        <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <state key="normal" title="Choose a station above to begin">
-                                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </state>
                                         <connections>
                                             <action selector="nowPlayingPressed:" destination="enP-TM-Wa7" eventType="touchUpInside" id="04j-pe-FI8"/>
@@ -88,7 +95,7 @@
                                         </constraints>
                                     </imageView>
                                 </subviews>
-                                <color key="backgroundColor" red="0.15686274509803921" green="0.15686274509803921" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="backgroundColor" red="0.1175440177321434" green="0.11671449244022369" blue="0.14129963517189026" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="LhZ-Go-zL7" secondAttribute="trailing" constant="8" id="EHx-A6-uMp"/>
                                     <constraint firstAttribute="height" constant="44" id="FfH-MV-hND"/>
@@ -100,7 +107,7 @@
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="XnL-lx-4Ua" firstAttribute="top" secondItem="y05-35-5xn" secondAttribute="bottom" id="0Ab-ql-g3F"/>
                             <constraint firstItem="dhg-xW-Q3M" firstAttribute="leading" secondItem="OvF-E7-hdu" secondAttribute="leading" id="8YJ-iI-LfY"/>
@@ -126,12 +133,11 @@
                         <outlet property="nowPlayingAnimationImageView" destination="ySP-43-Zqt" id="M7e-Co-EX1"/>
                         <outlet property="stationNowPlayingButton" destination="LhZ-Go-zL7" id="6CD-3L-Opj"/>
                         <outlet property="tableView" destination="dhg-xW-Q3M" id="Aug-Bc-jTR"/>
-                        <segue destination="vXZ-lx-hvc" kind="push" identifier="NowPlaying" id="Bfy-ow-vKF"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="7Wn-sj-N6f" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="281" y="429"/>
+            <point key="canvasLocation" x="266" y="429"/>
         </scene>
         <!--Menu View Controller-->
         <scene sceneID="4lL-TA-52h">
@@ -142,17 +148,18 @@
                         <viewControllerLayoutGuide type="bottom" id="HV6-5A-QuQ"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="OfZ-BE-wMy">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="background" translatesAutoresizingMaskIntoConstraints="NO" id="GpH-v2-Q95" userLabel="Background Image View">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                             </imageView>
                             <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="K6v-dQ-Ces" userLabel="Pop-up View">
-                                <rect key="frame" x="35" y="181" width="250" height="206"/>
+                                <rect key="frame" x="62.5" y="230.5" width="250" height="206"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Open Source Project" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HWZ-je-blg">
                                         <rect key="frame" x="28" y="151" width="192" height="28"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="14"/>
                                         <nil key="highlightedColor"/>
                                     </label>
@@ -162,7 +169,7 @@
                                             <constraint firstAttribute="height" constant="16" id="Fwj-Pc-cZx"/>
                                             <constraint firstAttribute="width" constant="16" id="zOq-pb-kph"/>
                                         </constraints>
-                                        <color key="tintColor" red="0.25490196078431371" green="0.56862745098039214" blue="0.76078431372549016" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="tintColor" red="0.20579981803894043" green="0.49201503396034241" blue="0.70883911848068237" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <state key="normal" image="btn-close"/>
                                         <connections>
                                             <action selector="closeButtonPressed" destination="61j-j7-6ve" eventType="touchUpInside" id="i59-HZ-ayG"/>
@@ -170,17 +177,19 @@
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Created by: Matthew Fecher" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hYi-2l-6dj">
                                         <rect key="frame" x="-10" y="170" width="269" height="28"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="14"/>
-                                        <color key="textColor" white="0.0" alpha="0.5" colorSpace="calibratedWhite"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NDa-S4-n0n" customClass="SpringButton" customModule="SwiftRadio" customModuleProvider="target">
                                         <rect key="frame" x="124" y="103" width="86" height="32"/>
-                                        <color key="backgroundColor" red="0.25490196078431371" green="0.56862745098039214" blue="0.76078431372549016" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <color key="backgroundColor" red="0.20579981803894043" green="0.49201503396034241" blue="0.70883911848068237" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="16"/>
-                                        <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <state key="normal" title="Website">
-                                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </state>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="boolean" keyPath="autostart" value="YES"/>
@@ -198,11 +207,12 @@
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Be5-hL-qtx" customClass="SpringButton" customModule="SwiftRadio" customModuleProvider="target">
                                         <rect key="frame" x="38" y="103" width="86" height="32"/>
-                                        <color key="backgroundColor" red="0.30196078431372547" green="0.63529411764705879" blue="0.84705882352941175" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <color key="backgroundColor" red="0.24706900119781494" green="0.56329798698425293" blue="0.81052231788635254" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="16"/>
-                                        <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <state key="normal" title="About">
-                                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </state>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="boolean" keyPath="autostart" value="YES"/>
@@ -220,6 +230,7 @@
                                     </button>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="swift-radio-black" translatesAutoresizingMaskIntoConstraints="NO" id="6p5-La-eLs" customClass="SpringImageView" customModule="SwiftRadio" customModuleProvider="target">
                                         <rect key="frame" x="44" y="34" width="162" height="61"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="boolean" keyPath="autostart" value="YES"/>
                                             <userDefinedRuntimeAttribute type="string" keyPath="animation" value="zoomIn"/>
@@ -229,7 +240,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </imageView>
                                 </subviews>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstItem="4YL-N4-xkC" firstAttribute="top" secondItem="K6v-dQ-Ces" secondAttribute="top" constant="8" id="EP4-Qc-tOn"/>
                                     <constraint firstItem="4YL-N4-xkC" firstAttribute="leading" secondItem="K6v-dQ-Ces" secondAttribute="leading" constant="8" id="LJH-vM-Cww"/>
@@ -238,7 +249,7 @@
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" white="0.0" alpha="0.5" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="GpH-v2-Q95" secondAttribute="trailing" id="2ZC-Gw-pfb"/>
                             <constraint firstItem="GpH-v2-Q95" firstAttribute="leading" secondItem="OfZ-BE-wMy" secondAttribute="leading" id="5h5-Vc-Qn3"/>
@@ -260,38 +271,38 @@
         <!--Now Playing View-->
         <scene sceneID="ufC-wZ-h7g">
             <objects>
-                <viewController id="vXZ-lx-hvc" userLabel="Now Playing View" customClass="NowPlayingViewController" customModule="SwiftRadio" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="NowPlayingViewController" id="vXZ-lx-hvc" userLabel="Now Playing View" customClass="NowPlayingViewController" customModule="SwiftRadio" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="jyV-Pf-zRb"/>
                         <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="kh9-bI-dsS">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="background" translatesAutoresizingMaskIntoConstraints="NO" id="uXf-Wr-UiK" userLabel="Background Image View">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                             </imageView>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="obn-8m-awZ" userLabel="AlbumArt" customClass="SpringImageView" customModule="SwiftRadio" customModuleProvider="target">
-                                <rect key="frame" x="70" y="101" width="180" height="180"/>
+                                <rect key="frame" x="70" y="101" width="235" height="180"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="180" id="hCD-tK-vVP"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Song Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="KC8-ZG-rx5" userLabel="Song Label" customClass="SpringLabel" customModule="SwiftRadio" customModuleProvider="target">
-                                <rect key="frame" x="16" y="442" width="288" height="33"/>
+                                <rect key="frame" x="16" y="442" width="343" height="33"/>
                                 <fontDescription key="fontDescription" name="AvenirNext-Medium" family="Avenir Next" pointSize="24"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Artist Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="v3l-q6-g0h" userLabel="Artist Label">
                                 <rect key="frame" x="16" y="463" width="288" height="25"/>
                                 <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="18"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JCK-L1-2Sc" userLabel="PlayerControls View">
-                                <rect key="frame" x="91" y="298" width="138" height="70"/>
+                                <rect key="frame" x="118.5" y="298" width="138" height="70"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="D3H-co-r2v" userLabel="PlayButton">
                                         <rect key="frame" x="73" y="20" width="45" height="45"/>
@@ -300,7 +311,7 @@
                                             <constraint firstAttribute="height" constant="45" id="z57-mJ-vRD"/>
                                         </constraints>
                                         <state key="normal" image="btn-play">
-                                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </state>
                                         <connections>
                                             <action selector="playPressed" destination="vXZ-lx-hvc" eventType="touchUpInside" id="0gS-uM-VCB"/>
@@ -313,7 +324,7 @@
                                             <constraint firstAttribute="height" constant="45" id="9ls-Nq-FcF"/>
                                         </constraints>
                                         <state key="normal" image="btn-pause">
-                                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </state>
                                         <connections>
                                             <action selector="pausePressed" destination="vXZ-lx-hvc" eventType="touchUpInside" id="wrn-Yt-4PQ"/>
@@ -331,56 +342,56 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GIj-4c-kRh" userLabel="Company-Button">
-                                <rect key="frame" x="12" y="524" width="90" height="36"/>
+                                <rect key="frame" x="12" y="623" width="90" height="36"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="90" id="Qr8-LJ-AFv"/>
                                     <constraint firstAttribute="height" constant="36" id="m1i-gc-0rZ"/>
                                 </constraints>
                                 <state key="normal" image="logo">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <segue destination="XU1-sh-p0s" kind="modal" modalTransitionStyle="flipHorizontal" id="Z22-bU-Ytg"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="infoLight" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yfv-H0-2Po" userLabel="InformationButton">
-                                <rect key="frame" x="286" y="534" width="22" height="22"/>
+                                <rect key="frame" x="341" y="633" width="22" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="22" id="IbM-ag-eBx"/>
                                     <constraint firstAttribute="width" constant="22" id="LtX-vH-4q5"/>
                                 </constraints>
-                                <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal">
-                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="infoButtonPressed:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="WwX-P9-9eK"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RA9-OX-Xr1" userLabel="Station Desc Label">
-                                <rect key="frame" x="70" y="249" width="180" height="21"/>
+                                <rect key="frame" x="70" y="249" width="235" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="wJP-em-2hX"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="15"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dtX-QN-LoN">
-                                <rect key="frame" x="0.0" y="378" width="320" height="60"/>
+                                <rect key="frame" x="0.0" y="378" width="375" height="60"/>
                                 <subviews>
                                     <view alpha="0.49999999999999961" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zuj-rb-EKQ" userLabel="Volume View">
-                                        <rect key="frame" x="35" y="10" width="250" height="36"/>
+                                        <rect key="frame" x="35" y="10" width="305" height="36"/>
                                         <subviews>
                                             <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="iFC-eW-7WA">
-                                                <rect key="frame" x="-2" y="3" width="254" height="31"/>
+                                                <rect key="frame" x="-2" y="3" width="309" height="31"/>
                                                 <connections>
                                                     <action selector="volumeChanged:" destination="vXZ-lx-hvc" eventType="valueChanged" id="ybI-Ho-WvA"/>
                                                 </connections>
                                             </slider>
                                         </subviews>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="bottom" secondItem="iFC-eW-7WA" secondAttribute="bottom" constant="3" id="KJ0-i6-dYU"/>
                                             <constraint firstItem="iFC-eW-7WA" firstAttribute="top" secondItem="zuj-rb-EKQ" secondAttribute="top" constant="3" id="PM6-85-Xp4"/>
@@ -397,14 +408,14 @@
                                         </constraints>
                                     </imageView>
                                     <imageView userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="vol-max" translatesAutoresizingMaskIntoConstraints="NO" id="Ygz-Co-31f">
-                                        <rect key="frame" x="290" y="22" width="18" height="16"/>
+                                        <rect key="frame" x="345" y="22" width="18" height="16"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="16" id="CHB-nF-bb4"/>
                                             <constraint firstAttribute="width" constant="18" id="t9O-wR-FB0"/>
                                         </constraints>
                                     </imageView>
                                 </subviews>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstItem="Kmj-vC-DQe" firstAttribute="top" secondItem="dtX-QN-LoN" secondAttribute="top" constant="22" id="Moz-Sz-poa"/>
                                     <constraint firstItem="Kmj-vC-DQe" firstAttribute="leading" secondItem="dtX-QN-LoN" secondAttribute="leading" constant="12" id="NfA-Gl-fzP"/>
@@ -419,22 +430,22 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3BY-Uw-fd7" userLabel="Share Button">
-                                <rect key="frame" x="252" y="530" width="26" height="26"/>
+                                <rect key="frame" x="307" y="629" width="26" height="26"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="26" id="OdL-jY-2i8"/>
                                     <constraint firstAttribute="height" constant="26" id="WCg-3H-2ht"/>
                                 </constraints>
-                                <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal" image="share">
-                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="shareButtonPressed:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="R3w-2U-Wb8"/>
                                 </connections>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="centerX" secondItem="JCK-L1-2Sc" secondAttribute="centerX" id="1Wd-Ce-ie0"/>
                             <constraint firstItem="obn-8m-awZ" firstAttribute="leading" secondItem="RA9-OX-Xr1" secondAttribute="leading" id="4LO-kb-G6v"/>
@@ -493,11 +504,11 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="kFn-Yc-mPh">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                        <color key="barTintColor" red="0.15686274509803921" green="0.15686274509803921" blue="0.18823529411764706" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="barTintColor" red="0.1175440177321434" green="0.11671449244022369" blue="0.14129963517189026" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <textAttributes key="titleTextAttributes">
                             <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="20"/>
-                            <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                            <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         </textAttributes>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -507,7 +518,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="wQK-JQ-AqM" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-121" y="429"/>
+            <point key="canvasLocation" x="-164" y="429"/>
         </scene>
         <!--Info View Controller-->
         <scene sceneID="abW-KU-RWK">
@@ -518,49 +529,49 @@
                         <viewControllerLayoutGuide type="bottom" id="E91-K7-5sw"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="s9T-KA-lNI">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="background" translatesAutoresizingMaskIntoConstraints="NO" id="fdb-DQ-3fT" userLabel="Background Image View">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sub Pop Records" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IEm-3W-Db6">
-                                <rect key="frame" x="134" y="99" width="170" height="21"/>
+                                <rect key="frame" x="134" y="99" width="225" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="LvN-NI-AcB"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" name="AvenirNext-Medium" family="Avenir Next" pointSize="18"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Mid-sized Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vLU-OR-FSU">
-                                <rect key="frame" x="134" y="120" width="170" height="21"/>
+                                <rect key="frame" x="134" y="120" width="225" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="5pu-sv-mbc"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="16"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cJI-ka-9k5">
-                                <rect key="frame" x="16" y="162" width="288" height="235"/>
+                                <rect key="frame" x="16" y="162" width="343" height="213"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="lessThanOrEqual" priority="750" constant="340" id="ulU-kP-hZB"/>
                                 </constraints>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</string>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="16"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Btu-bZ-7Pz">
-                                <rect key="frame" x="16" y="512" width="288" height="36"/>
-                                <color key="backgroundColor" red="0.20000000000000001" green="0.20000000000000001" blue="0.20784313725490197" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <rect key="frame" x="16" y="611" width="343" height="36"/>
+                                <color key="backgroundColor" red="0.15054957568645477" green="0.15034264326095581" blue="0.15674735605716705" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="36" id="Gpj-99-oS5"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" name="AvenirNext-Medium" family="Avenir Next" pointSize="16"/>
                                 <state key="normal" title="Okay">
-                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="okayButtonPressed:" destination="bg5-7y-kdG" eventType="touchUpInside" id="9TB-Rq-c2B"/>
@@ -574,7 +585,7 @@
                                 </constraints>
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="fdb-DQ-3fT" secondAttribute="trailing" id="50c-4f-6Rq"/>
                             <constraint firstItem="E91-K7-5sw" firstAttribute="top" secondItem="fdb-DQ-3fT" secondAttribute="bottom" id="Deu-DP-ZdA"/>
@@ -620,11 +631,11 @@
                         <viewControllerLayoutGuide type="bottom" id="vCl-Js-ebt"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="gkA-NG-Bu8">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="background" translatesAutoresizingMaskIntoConstraints="NO" id="FDJ-eG-GLD" userLabel="Background Image View">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                             </imageView>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logo" translatesAutoresizingMaskIntoConstraints="NO" id="Paf-Ad-5GK">
                                 <rect key="frame" x="16" y="32" width="120" height="80"/>
@@ -634,46 +645,46 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Xcode 7/Swift 2" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vTb-3H-cug">
-                                <rect key="frame" x="144" y="50" width="160" height="25"/>
+                                <rect key="frame" x="144" y="50" width="215" height="25"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="25" id="Jjn-aw-6Ea"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" name="AvenirNext-Medium" family="Avenir Next" pointSize="17"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Radio App" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gcd-mM-ZPe">
-                                <rect key="frame" x="144" y="72" width="160" height="22"/>
+                                <rect key="frame" x="144" y="72" width="215" height="22"/>
                                 <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="16"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SBf-Hj-mZ8">
-                                <rect key="frame" x="78" y="445" width="164" height="37"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                <rect key="frame" x="106" y="544" width="164" height="37"/>
+                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="37" id="56M-jK-IWd"/>
                                     <constraint firstAttribute="width" constant="164" id="Vri-Jx-J1g"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="18"/>
-                                <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal" title="matthewfecher.com">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="websiteButtonDidTouch:" destination="XU1-sh-p0s" eventType="touchUpInside" id="nwb-md-4Wf"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qFQ-Uk-iUq">
-                                <rect key="frame" x="16" y="512" width="288" height="36"/>
-                                <color key="backgroundColor" red="0.2627450980392157" green="0.2627450980392157" blue="0.27058823529411763" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <rect key="frame" x="16" y="611" width="343" height="36"/>
+                                <color key="backgroundColor" red="0.20187027752399445" green="0.2016473114490509" blue="0.20853230357170105" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="36" id="EYd-7e-NvX"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" name="AvenirNext-Medium" family="Avenir Next" pointSize="16"/>
                                 <inset key="imageEdgeInsets" minX="-16" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 <state key="normal" title="Okay">
-                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <segue destination="p1c-PP-VS5" kind="unwind" unwindAction="unwindToViewController:" id="FtM-nA-Nbl"/>
@@ -690,27 +701,27 @@
 + Loads and parses Icecast metadata (i.e. artist &amp; track names)
 + Ability to update stations from server without resubmitting to the app store.
 </string>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="16"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1G4-to-fqL">
-                                <rect key="frame" x="33" y="471" width="255" height="37"/>
+                                <rect key="frame" x="60" y="570" width="255" height="37"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="255" id="Cum-9W-pGw"/>
                                     <constraint firstAttribute="height" constant="37" id="N2q-ma-sDO"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" name="AvenirNext-UltraLight" family="Avenir Next" pointSize="18"/>
-                                <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal" title="email me">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="emailButtonDidTouch:" destination="XU1-sh-p0s" eventType="touchUpInside" id="6Sq-De-gZu"/>
                                 </connections>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="centerX" secondItem="1G4-to-fqL" secondAttribute="centerX" id="0VD-xL-kgp"/>
                             <constraint firstItem="qFQ-Uk-iUq" firstAttribute="top" secondItem="1G4-to-fqL" secondAttribute="bottom" constant="4" id="5pr-Lw-YEX"/>
@@ -745,19 +756,24 @@
         </scene>
     </scenes>
     <resources>
-        <image name="NowPlayingBars" width="20" height="19"/>
+        <image name="NowPlayingBars" width="19" height="19"/>
         <image name="background" width="320" height="568"/>
-        <image name="btn-close" width="23" height="23"/>
+        <image name="btn-close" width="22" height="22"/>
         <image name="btn-pause" width="44" height="44"/>
         <image name="btn-play" width="44" height="44"/>
         <image name="icon-hamburger" width="22" height="16"/>
-        <image name="logo" width="180" height="71"/>
+        <image name="logo" width="90" height="35"/>
         <image name="share" width="32" height="32"/>
         <image name="stationImage" width="120" height="75"/>
-        <image name="swift-radio-black" width="180" height="71"/>
-        <image name="vol-max" width="17" height="14"/>
-        <image name="vol-min" width="11" height="13"/>
+        <image name="swift-radio-black" width="180" height="70"/>
+        <image name="vol-max" width="16" height="14"/>
+        <image name="vol-min" width="11" height="12"/>
     </resources>
+    <simulatedMetricsContainer key="defaultSimulatedMetrics">
+        <simulatedStatusBarMetrics key="statusBar"/>
+        <simulatedOrientationMetrics key="orientation"/>
+        <simulatedScreenMetrics key="destination" type="retina4_7.fullscreen"/>
+    </simulatedMetricsContainer>
     <inferredMetricsTieBreakers>
         <segue reference="Z22-bU-Ytg"/>
     </inferredMetricsTieBreakers>

--- a/SwiftRadio/CustomAVPlayerItem.swift
+++ b/SwiftRadio/CustomAVPlayerItem.swift
@@ -9,7 +9,7 @@ import Foundation
 
 
 protocol CustomAVPlayerItemDelegate {
-    func onMetaData(metaData:[AVMetadataItem]?)
+    func onMetaData(_ metaData:[AVMetadataItem]?)
 }
 
 //*****************************************************************
@@ -20,11 +20,11 @@ class CustomAVPlayerItem: AVPlayerItem {
     
     var delegate : CustomAVPlayerItemDelegate?
     
-    init(URL:NSURL)
+    init(url URL:URL)
     {
         if kDebugLog {print("CustomAVPlayerItem.init")}
-        super.init(asset: AVAsset(URL: URL) , automaticallyLoadedAssetKeys:[])
-        addObserver(self, forKeyPath: "timedMetadata", options: NSKeyValueObservingOptions.New, context: nil)
+        super.init(asset: AVAsset(url: URL) , automaticallyLoadedAssetKeys:[])
+        addObserver(self, forKeyPath: "timedMetadata", options: NSKeyValueObservingOptions.new, context: nil)
     }
     
     deinit{        
@@ -32,7 +32,7 @@ class CustomAVPlayerItem: AVPlayerItem {
         removeObserver(self, forKeyPath: "timedMetadata")
     }
     
-    override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
         if let avpItem: AVPlayerItem = object as? AVPlayerItem {
             if keyPath == "timedMetadata" {                
                 delegate?.onMetaData(avpItem.timedMetadata)

--- a/SwiftRadio/Extensions.swift
+++ b/SwiftRadio/Extensions.swift
@@ -1,0 +1,16 @@
+//
+//  Extensions.swift
+//  Staradio
+//
+//  Created by Giacomo Marangoni on 15/12/16.
+//  Copyright © 2016 matthewfecher.com. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+    func decodeAllChars() -> String{
+        let dataStr = self.data(using: String.Encoding.isoLatin1)
+        return String(data: dataStr!, encoding: String.Encoding.utf8)!
+    }
+}

--- a/SwiftRadio/Extensions.swift
+++ b/SwiftRadio/Extensions.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 extension String {
-    func decodeAllChars() -> String{
+    func decodeAll() -> String{
         let dataStr = self.data(using: String.Encoding.isoLatin1)
         return String(data: dataStr!, encoding: String.Encoding.utf8)!
     }

--- a/SwiftRadio/InfoDetailViewController.swift
+++ b/SwiftRadio/InfoDetailViewController.swift
@@ -17,7 +17,7 @@ class InfoDetailViewController: UIViewController {
     @IBOutlet weak var okayButton: UIButton!
     
     var currentStation: RadioStation!
-    var downloadTask: NSURLSessionDownloadTask?
+    var downloadTask: URLSessionDownloadTask?
 
     //*****************************************************************
     // MARK: - ViewDidLoad
@@ -64,9 +64,9 @@ class InfoDetailViewController: UIViewController {
         // Display Station Image/Logo
         let imageURL = currentStation.stationImageURL
         
-        if imageURL.rangeOfString("http") != nil {
+        if imageURL.range(of: "http") != nil {
             // Get station image from the web, iOS should cache the image
-            if let url = NSURL(string: currentStation.stationImageURL) {
+            if let url = URL(string: currentStation.stationImageURL) {
                 downloadTask = stationImageView.loadImageWithURL(url) { _ in }
             }
             
@@ -87,8 +87,8 @@ class InfoDetailViewController: UIViewController {
     // MARK: - IBActions
     //*****************************************************************
     
-    @IBAction func okayButtonPressed(sender: UIButton) {
-        navigationController?.popViewControllerAnimated(true)
+    @IBAction func okayButtonPressed(_ sender: UIButton) {
+        _ = navigationController?.popViewController(animated: true)
     }
     
 }

--- a/SwiftRadio/Libraries/Spring/AsyncButton.swift
+++ b/SwiftRadio/Libraries/Spring/AsyncButton.swift
@@ -23,28 +23,29 @@
 import UIKit
 
 public class AsyncButton: UIButton {
-
+    
     private var imageURL = [UInt:NSURL]()
     private var placeholderImage = [UInt:UIImage]()
-
-
+    
+    
     public func setImageURL(url: NSURL?, placeholderImage placeholder:UIImage?, forState state:UIControlState) {
-
+        
         imageURL[state.rawValue] = url
         placeholderImage[state.rawValue] = placeholder
-
+        
         if let urlString = url?.absoluteString {
-            ImageLoader.sharedLoader.imageForUrl(urlString) { [weak self] image, url in
-
+            ImageLoader.sharedLoader.imageForUrl(urlString: urlString) { [weak self] image, url in
+                
                 if let strongSelf = self {
-                    dispatch_async(dispatch_get_main_queue(), { () -> Void in
+                    
+                    DispatchQueue.main.async(execute: { () -> Void in
                         if strongSelf.imageURL[state.rawValue]?.absoluteString == url {
-                            strongSelf.setImage(image, forState: state)
+                            strongSelf.setImage(image, for: state)
                         }
                     })
                 }
             }
         }
     }
-
+    
 }

--- a/SwiftRadio/Libraries/Spring/AsyncImageView.swift
+++ b/SwiftRadio/Libraries/Spring/AsyncImageView.swift
@@ -30,9 +30,9 @@ public class AsyncImageView: UIImageView {
         didSet {
             self.image = placeholderImage
             if let urlString = url?.absoluteString {
-                ImageLoader.sharedLoader.imageForUrl(urlString) { [weak self] image, url in
+                ImageLoader.sharedLoader.imageForUrl(urlString: urlString) { [weak self] image, url in
                     if let strongSelf = self {
-                        dispatch_async(dispatch_get_main_queue(), { () -> Void in
+                        DispatchQueue.main.async(execute: { () -> Void in
                             if strongSelf.url?.absoluteString == url {
                                 strongSelf.image = image ?? strongSelf.placeholderImage
                             }

--- a/SwiftRadio/Libraries/Spring/AutoTextView.swift
+++ b/SwiftRadio/Libraries/Spring/AutoTextView.swift
@@ -9,16 +9,19 @@
 import UIKit
 
 public class AutoTextView: UITextView {
-    override public func intrinsicContentSize() -> CGSize {
-        var size = self.sizeThatFits(CGSizeMake(self.frame.size.width, CGFloat.max))
-        size.width = self.frame.size.width
-        if text.length == 0 {
-            size.height = 0
+
+    public override var intrinsicContentSize: CGSize {
+        get {
+            var size = self.sizeThatFits(CGSize(width: self.frame.size.width, height: CGFloat.greatestFiniteMagnitude))
+            size.width = self.frame.size.width
+            if text.length == 0 {
+                size.height = 0
+            }
+            
+            contentInset = UIEdgeInsets(top: -4, left: -4, bottom: -4, right: -4)
+            layoutIfNeeded()
+            
+            return size
         }
-        
-        contentInset = UIEdgeInsetsMake(-4, -4, -4, -4)
-        layoutIfNeeded()
-        
-        return size
     }
 }

--- a/SwiftRadio/Libraries/Spring/BlurView.swift
+++ b/SwiftRadio/Libraries/Spring/BlurView.swift
@@ -23,11 +23,11 @@
 import UIKit
 
 public func insertBlurView (view: UIView, style: UIBlurEffectStyle) -> UIVisualEffectView {
-    view.backgroundColor = UIColor.clearColor()
+    view.backgroundColor = UIColor.clear
     
     let blurEffect = UIBlurEffect(style: style)
     let blurEffectView = UIVisualEffectView(effect: blurEffect)
     blurEffectView.frame = view.bounds
-    view.insertSubview(blurEffectView, atIndex: 0)
+    view.insertSubview(blurEffectView, at: 0)
     return blurEffectView
 }

--- a/SwiftRadio/Libraries/Spring/DesignableButton.swift
+++ b/SwiftRadio/Libraries/Spring/DesignableButton.swift
@@ -24,9 +24,9 @@ import UIKit
 
 @IBDesignable public class DesignableButton: SpringButton {
 
-    @IBInspectable public var borderColor: UIColor = UIColor.clearColor() {
+    @IBInspectable public var borderColor: UIColor = UIColor.clear {
         didSet {
-            layer.borderColor = borderColor.CGColor
+            layer.borderColor = borderColor.cgColor
         }
     }
     
@@ -42,9 +42,9 @@ import UIKit
         }
     }
     
-    @IBInspectable public var shadowColor: UIColor = UIColor.clearColor() {
+    @IBInspectable public var shadowColor: UIColor = UIColor.clear {
         didSet {
-            layer.shadowColor = shadowColor.CGColor
+            layer.shadowColor = shadowColor.cgColor
         }
     }
     

--- a/SwiftRadio/Libraries/Spring/DesignableImageView.swift
+++ b/SwiftRadio/Libraries/Spring/DesignableImageView.swift
@@ -24,9 +24,9 @@ import UIKit
 
 @IBDesignable public class DesignableImageView: SpringImageView {
     
-    @IBInspectable public var borderColor: UIColor = UIColor.clearColor() {
+    @IBInspectable public var borderColor: UIColor = UIColor.clear {
         didSet {
-            layer.borderColor = borderColor.CGColor
+            layer.borderColor = borderColor.cgColor
         }
     }
     

--- a/SwiftRadio/Libraries/Spring/DesignableTabBarController.swift
+++ b/SwiftRadio/Libraries/Spring/DesignableTabBarController.swift
@@ -24,23 +24,23 @@ import UIKit
 
 @IBDesignable class DesignableTabBarController: UITabBarController {
     
-    @IBInspectable var normalTint: UIColor = UIColor.clearColor() {
+    @IBInspectable var normalTint: UIColor = UIColor.clear {
         didSet {
             UITabBar.appearance().tintColor = normalTint
-            UITabBarItem.appearance().setTitleTextAttributes([NSForegroundColorAttributeName: normalTint], forState: UIControlState.Normal)
+            UITabBarItem.appearance().setTitleTextAttributes([NSForegroundColorAttributeName: normalTint], for: UIControlState())
         }
     }
     
-    @IBInspectable var selectedTint: UIColor = UIColor.clearColor() {
+    @IBInspectable var selectedTint: UIColor = UIColor.clear {
         didSet {
             UITabBar.appearance().tintColor = selectedTint
-            UITabBarItem.appearance().setTitleTextAttributes([NSForegroundColorAttributeName: selectedTint], forState:UIControlState.Selected)
+            UITabBarItem.appearance().setTitleTextAttributes([NSForegroundColorAttributeName: selectedTint], for:UIControlState.selected)
         }
     }
     
     @IBInspectable var fontName: String = "" {
         didSet {
-            UITabBarItem.appearance().setTitleTextAttributes([NSForegroundColorAttributeName: normalTint, NSFontAttributeName: UIFont(name: fontName, size: 11)!], forState: UIControlState.Normal)
+            UITabBarItem.appearance().setTitleTextAttributes([NSForegroundColorAttributeName: normalTint, NSFontAttributeName: UIFont(name: fontName, size: 11)!], for: UIControlState())
         }
     }
     
@@ -48,7 +48,7 @@ import UIKit
         didSet {
             if let image = firstSelectedImage {
                 var tabBarItems = self.tabBar.items as [UITabBarItem]!
-                tabBarItems[0].selectedImage = image.imageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate)
+                tabBarItems?[0].selectedImage = image.withRenderingMode(UIImageRenderingMode.alwaysTemplate)
             }
         }
     }
@@ -57,7 +57,7 @@ import UIKit
         didSet {
             if let image = secondSelectedImage {
                 var tabBarItems = self.tabBar.items as [UITabBarItem]!
-                tabBarItems[1].selectedImage = image.imageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate)
+                tabBarItems?[1].selectedImage = image.withRenderingMode(UIImageRenderingMode.alwaysTemplate)
             }
         }
     }
@@ -66,7 +66,7 @@ import UIKit
         didSet {
             if let image = thirdSelectedImage {
                 var tabBarItems = self.tabBar.items as [UITabBarItem]!
-                tabBarItems[2].selectedImage = image.imageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate)
+                tabBarItems?[2].selectedImage = image.withRenderingMode(UIImageRenderingMode.alwaysTemplate)
             }
         }
     }
@@ -75,7 +75,7 @@ import UIKit
         didSet {
             if let image = fourthSelectedImage {
                 var tabBarItems = self.tabBar.items as [UITabBarItem]!
-                tabBarItems[3].selectedImage = image.imageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate)
+                tabBarItems?[3].selectedImage = image.withRenderingMode(UIImageRenderingMode.alwaysTemplate)
             }
         }
     }
@@ -84,7 +84,7 @@ import UIKit
         didSet {
             if let image = fifthSelectedImage {
                 var tabBarItems = self.tabBar.items as [UITabBarItem]!
-                tabBarItems[4].selectedImage = image.imageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate)
+                tabBarItems?[4].selectedImage = image.withRenderingMode(UIImageRenderingMode.alwaysTemplate)
             }
         }
     }
@@ -94,7 +94,7 @@ import UIKit
         
         for item in self.tabBar.items as [UITabBarItem]! {
             if let image = item.image {
-                item.image = image.imageWithColor(self.normalTint).imageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal)
+                item.image = image.imageWithColor(tintColor: self.normalTint).withRenderingMode(UIImageRenderingMode.alwaysOriginal)
             }
         }
     }
@@ -105,14 +105,14 @@ extension UIImage {
         UIGraphicsBeginImageContextWithOptions(self.size, false, self.scale)
         
         let context = UIGraphicsGetCurrentContext()
-        CGContextTranslateCTM(context!, 0, self.size.height)
-        CGContextScaleCTM(context!, 1.0, -1.0);
-        CGContextSetBlendMode(context!, CGBlendMode.Normal)
+        context!.translateBy(x: 0, y: self.size.height)
+        context!.scaleBy(x: 1.0, y: -1.0);
+        context!.setBlendMode(CGBlendMode.normal)
         
-        let rect = CGRectMake(0, 0, self.size.width, self.size.height) as CGRect
-        CGContextClipToMask(context!, rect, self.CGImage!)
+        let rect = CGRect(x: 0, y: 0, width: self.size.width, height: self.size.height)
+        context?.clip(to: rect, mask: self.cgImage!)
         tintColor.setFill()
-        CGContextFillRect(context!, rect)
+        context!.fill(rect)
         
         let newImage = UIGraphicsGetImageFromCurrentImageContext()! as UIImage
         UIGraphicsEndImageContext()

--- a/SwiftRadio/Libraries/Spring/DesignableTextField.swift
+++ b/SwiftRadio/Libraries/Spring/DesignableTextField.swift
@@ -24,7 +24,7 @@ import UIKit
 
 @IBDesignable public class DesignableTextField: SpringTextField {
     
-    @IBInspectable public var placeholderColor: UIColor = UIColor.clearColor() {
+    @IBInspectable public var placeholderColor: UIColor = UIColor.clear {
         didSet {
             attributedPlaceholder = NSAttributedString(string: placeholder!, attributes: [NSForegroundColorAttributeName: placeholderColor])
             layoutSubviews()
@@ -34,37 +34,37 @@ import UIKit
     
     @IBInspectable public var sidePadding: CGFloat = 0 {
         didSet {
-            let padding = UIView(frame: CGRectMake(0, 0, sidePadding, sidePadding))
+            let padding = UIView(frame: CGRect(x: 0, y: 0, width: sidePadding, height: sidePadding))
             
-            leftViewMode = UITextFieldViewMode.Always
+            leftViewMode = UITextFieldViewMode.always
             leftView = padding
             
-            rightViewMode = UITextFieldViewMode.Always
+            rightViewMode = UITextFieldViewMode.always
             rightView = padding
         }
     }
     
     @IBInspectable public var leftPadding: CGFloat = 0 {
         didSet {
-            let padding = UIView(frame: CGRectMake(0, 0, leftPadding, 0))
+            let padding = UIView(frame: CGRect(x: 0, y: 0, width: leftPadding, height: 0))
             
-            leftViewMode = UITextFieldViewMode.Always
+            leftViewMode = UITextFieldViewMode.always
             leftView = padding
         }
     }
     
     @IBInspectable public var rightPadding: CGFloat = 0 {
         didSet {
-            let padding = UIView(frame: CGRectMake(0, 0, rightPadding, 0))
+            let padding = UIView(frame: CGRect(x: 0, y: 0, width: rightPadding, height: 0))
             
-            rightViewMode = UITextFieldViewMode.Always
+            rightViewMode = UITextFieldViewMode.always
             rightView = padding
         }
     }
     
-    @IBInspectable public var borderColor: UIColor = UIColor.clearColor() {
+    @IBInspectable public var borderColor: UIColor = UIColor.clear {
         didSet {
-            layer.borderColor = borderColor.CGColor
+            layer.borderColor = borderColor.cgColor
         }
     }
     
@@ -89,8 +89,8 @@ import UIKit
             paragraphStyle.lineSpacing = lineHeight
             
             let attributedString = NSMutableAttributedString(string: text!)
-            attributedString.addAttribute(NSParagraphStyleAttributeName, value: paragraphStyle, range: NSMakeRange(0, attributedString.length))
-            attributedString.addAttribute(NSFontAttributeName, value: font!, range: NSMakeRange(0, attributedString.length))
+            attributedString.addAttribute(NSParagraphStyleAttributeName, value: paragraphStyle, range: NSRange(location: 0, length: attributedString.length))
+            attributedString.addAttribute(NSFontAttributeName, value: font!, range: NSRange(location: 0, length: attributedString.length))
             
             self.attributedText = attributedString
         }

--- a/SwiftRadio/Libraries/Spring/DesignableTextView.swift
+++ b/SwiftRadio/Libraries/Spring/DesignableTextView.swift
@@ -24,9 +24,9 @@ import UIKit
 
 @IBDesignable public class DesignableTextView: SpringTextView {
     
-    @IBInspectable public var borderColor: UIColor = UIColor.clearColor() {
+    @IBInspectable public var borderColor: UIColor = UIColor.clear {
         didSet {
-            layer.borderColor = borderColor.CGColor
+            layer.borderColor = borderColor.cgColor
         }
     }
     
@@ -49,10 +49,10 @@ import UIKit
             
             let paragraphStyle = NSMutableParagraphStyle()
             paragraphStyle.lineSpacing = lineHeight
-            
+
             let attributedString = NSMutableAttributedString(string: text!)
-            attributedString.addAttribute(NSParagraphStyleAttributeName, value: paragraphStyle, range: NSMakeRange(0, attributedString.length))
-            attributedString.addAttribute(NSFontAttributeName, value: font!, range: NSMakeRange(0, attributedString.length))
+            attributedString.addAttribute(NSParagraphStyleAttributeName, value: paragraphStyle, range: NSRange(location: 0, length: attributedString.length))
+            attributedString.addAttribute(NSFontAttributeName, value: font!, range: NSRange(location: 0, length: attributedString.length))
             
             self.attributedText = attributedString
         }

--- a/SwiftRadio/Libraries/Spring/DesignableView.swift
+++ b/SwiftRadio/Libraries/Spring/DesignableView.swift
@@ -24,9 +24,9 @@ import UIKit
 
 @IBDesignable public class DesignableView: SpringView {
     
-    @IBInspectable public var borderColor: UIColor = UIColor.clearColor() {
+    @IBInspectable public var borderColor: UIColor = UIColor.clear {
         didSet {
-            layer.borderColor = borderColor.CGColor
+            layer.borderColor = borderColor.cgColor
         }
     }
     
@@ -42,9 +42,9 @@ import UIKit
         }
     }
     
-    @IBInspectable public var shadowColor: UIColor = UIColor.clearColor() {
+    @IBInspectable public var shadowColor: UIColor = UIColor.clear {
         didSet {
-            layer.shadowColor = shadowColor.CGColor
+            layer.shadowColor = shadowColor.cgColor
         }
     }
     

--- a/SwiftRadio/Libraries/Spring/ImageLoader.swift
+++ b/SwiftRadio/Libraries/Spring/ImageLoader.swift
@@ -26,45 +26,61 @@ import Foundation
 
 public class ImageLoader {
     
-    var cache = NSCache()
+    var cache = NSCache<NSString, NSData>()
     
     public class var sharedLoader : ImageLoader {
-    struct Static {
-        static let instance : ImageLoader = ImageLoader()
+        struct Static {
+            static let instance : ImageLoader = ImageLoader()
         }
         return Static.instance
     }
     
-    public func imageForUrl(urlString: String, completionHandler:(image: UIImage?, url: String) -> ()) {
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), {()in
-            let data: NSData? = self.cache.objectForKey(urlString) as? NSData
+    public func imageForUrl(urlString: String, completionHandler: @escaping(_ image: UIImage?, _ url: String) -> ()) {
+        DispatchQueue.global(qos: DispatchQoS.QoSClass.background).async { 
+            var data: NSData?
+            
+            if let dataCache = self.cache.object(forKey: urlString as NSString){
+                data = (dataCache) as NSData
+                
+            }else{
+                if (URL(string: urlString) != nil)
+                {
+                    data = NSData(contentsOf: URL(string: urlString)!)
+                    if data != nil {
+                        self.cache.setObject(data!, forKey: urlString as NSString)
+                    }
+                }else{
+                    return
+                }
+            }
             
             if let goodData = data {
-                let image = UIImage(data: goodData)
-                dispatch_async(dispatch_get_main_queue(), {() in
-                    completionHandler(image: image, url: urlString)
+                let image = UIImage(data: goodData as Data)
+                DispatchQueue.main.async(execute: {() in
+                    completionHandler(image, urlString)
                 })
                 return
             }
             
-            let downloadTask: NSURLSessionDataTask = NSURLSession.sharedSession().dataTaskWithURL(NSURL(string: urlString)!, completionHandler: { (data, response, error) -> Void in
+            let downloadTask: URLSessionDataTask = URLSession.shared.dataTask(with: URL(string: urlString)!, completionHandler: { (data, response, error) -> Void in
+                
                 if (error != nil) {
-                    completionHandler(image: nil, url: urlString)
+                    completionHandler(nil, urlString)
                     return
                 }
                 
                 if data != nil {
                     let image = UIImage(data: data!)
-                    self.cache.setObject(data!, forKey: urlString)
-                    dispatch_async(dispatch_get_main_queue(), {() in
-                        completionHandler(image: image, url: urlString)
+                    self.cache.setObject(data! as NSData, forKey: urlString as NSString)
+                    DispatchQueue.main.async(execute: {() in
+                        completionHandler(image, urlString)
                     })
                     return
                 }
             })
             downloadTask.resume()
             
-        })
+        }
         
     }
 }

--- a/SwiftRadio/Libraries/Spring/KeyboardLayoutConstraint.swift
+++ b/SwiftRadio/Libraries/Spring/KeyboardLayoutConstraint.swift
@@ -23,73 +23,73 @@
 import UIKit
 
 public class KeyboardLayoutConstraint: NSLayoutConstraint {
-
+    
     private var offset : CGFloat = 0
     private var keyboardVisibleHeight : CGFloat = 0
-
+    
     override public func awakeFromNib() {
         super.awakeFromNib()
-
+        
         offset = constant
-
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(KeyboardLayoutConstraint.keyboardWillShowNotification(_:)), name: UIKeyboardWillShowNotification, object: nil)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(KeyboardLayoutConstraint.keyboardWillHideNotification(_:)), name: UIKeyboardWillHideNotification, object: nil)
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(KeyboardLayoutConstraint.keyboardWillShowNotification(_:)), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(KeyboardLayoutConstraint.keyboardWillHideNotification(_:)), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
     }
-
+    
     deinit {
-        NSNotificationCenter.defaultCenter().removeObserver(self)
+        NotificationCenter.default.removeObserver(self)
     }
-
+    
     // MARK: Notification
-
-    func keyboardWillShowNotification(notification: NSNotification) {
+    
+    func keyboardWillShowNotification(_ notification: Notification) {
         if let userInfo = notification.userInfo {
             if let frameValue = userInfo[UIKeyboardFrameEndUserInfoKey] as? NSValue {
-                let frame = frameValue.CGRectValue()
+                let frame = frameValue.cgRectValue
                 keyboardVisibleHeight = frame.size.height
             }
-
+            
             self.updateConstant()
             switch (userInfo[UIKeyboardAnimationDurationUserInfoKey] as? NSNumber, userInfo[UIKeyboardAnimationCurveUserInfoKey] as? NSNumber) {
-            case let (.Some(duration), .Some(curve)):
-
-                let options = UIViewAnimationOptions(rawValue: curve.unsignedLongValue)
-
-                UIView.animateWithDuration(
-                    NSTimeInterval(duration.doubleValue),
+            case let (.some(duration), .some(curve)):
+                
+                let options = UIViewAnimationOptions(rawValue: curve.uintValue)
+                
+                UIView.animate(
+                    withDuration: TimeInterval(duration.doubleValue),
                     delay: 0,
                     options: options,
                     animations: {
-                        UIApplication.sharedApplication().keyWindow?.layoutIfNeeded()
+                        UIApplication.shared.keyWindow?.layoutIfNeeded()
                         return
                     }, completion: { finished in
                 })
             default:
-
+                
                 break
             }
-
+            
         }
-
+        
     }
-
-    func keyboardWillHideNotification(notification: NSNotification) {
+    
+    func keyboardWillHideNotification(_ notification: NSNotification) {
         keyboardVisibleHeight = 0
         self.updateConstant()
-
+        
         if let userInfo = notification.userInfo {
-
+            
             switch (userInfo[UIKeyboardAnimationDurationUserInfoKey] as? NSNumber, userInfo[UIKeyboardAnimationCurveUserInfoKey] as? NSNumber) {
-            case let (.Some(duration), .Some(curve)):
-
-                let options = UIViewAnimationOptions(rawValue: curve.unsignedLongValue)
-
-                UIView.animateWithDuration(
-                    NSTimeInterval(duration.doubleValue),
+            case let (.some(duration), .some(curve)):
+                
+                let options = UIViewAnimationOptions(rawValue: curve.uintValue)
+                
+                UIView.animate(
+                    withDuration: TimeInterval(duration.doubleValue),
                     delay: 0,
                     options: options,
                     animations: {
-                        UIApplication.sharedApplication().keyWindow?.layoutIfNeeded()
+                        UIApplication.shared.keyWindow?.layoutIfNeeded()
                         return
                     }, completion: { finished in
                 })
@@ -98,9 +98,9 @@ public class KeyboardLayoutConstraint: NSLayoutConstraint {
             }
         }
     }
-
+    
     func updateConstant() {
         self.constant = offset + keyboardVisibleHeight
     }
-
+    
 }

--- a/SwiftRadio/Libraries/Spring/LoadingView.swift
+++ b/SwiftRadio/Libraries/Spring/LoadingView.swift
@@ -29,15 +29,16 @@ public class LoadingView: UIView {
     override public func awakeFromNib() {
         let animation = CABasicAnimation()
         animation.keyPath = "transform.rotation.z"
-        animation.fromValue = degreesToRadians(0)
-        animation.toValue = degreesToRadians(360)
+        animation.fromValue = degreesToRadians(degrees: 0)
+        animation.toValue = degreesToRadians(degrees: 360)
         animation.duration = 0.9
         animation.repeatCount = HUGE
-        indicatorView.layer.addAnimation(animation, forKey: "")
+        indicatorView.layer.add(animation, forKey: "")
     }
 
     class func designCodeLoadingView() -> UIView {
-        return NSBundle(forClass: self).loadNibNamed("LoadingView", owner: self, options: nil)![0] as! UIView
+        
+        return Bundle(for: self).loadNibNamed("LoadingView", owner: self, options: nil)![0] as! UIView
     }
 }
 
@@ -60,7 +61,7 @@ public extension UIView {
         self.addSubview(loadingXibView)
 
         loadingXibView.alpha = 0
-        SpringAnimation.spring(0.7, animations: {
+        SpringAnimation.spring(duration: 0.7, animations: {
             loadingXibView.alpha = 1
         })
     }
@@ -70,9 +71,9 @@ public extension UIView {
         if let loadingXibView = self.viewWithTag(LoadingViewConstants.Tag) {
             loadingXibView.alpha = 1
 
-            SpringAnimation.springWithCompletion(0.7, animations: {
+            SpringAnimation.springWithCompletion(duration: 0.7, animations: {
                 loadingXibView.alpha = 0
-                loadingXibView.transform = CGAffineTransformMakeScale(3, 3)
+                loadingXibView.transform = CGAffineTransform(scaleX: 3, y: 3)
             }, completion: { (completed) -> Void in
                 loadingXibView.removeFromSuperview()
             })

--- a/SwiftRadio/Libraries/Spring/Misc.swift
+++ b/SwiftRadio/Libraries/Spring/Misc.swift
@@ -24,14 +24,14 @@ import UIKit
 
 public extension String {
     public var length: Int { return self.characters.count }
-
+    
     public func toURL() -> NSURL? {
         return NSURL(string: self)
     }
 }
 
 public func htmlToAttributedString(text: String) -> NSAttributedString! {
-    let htmlData = text.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
+    let htmlData = text.data(using: String.Encoding.utf8, allowLossyConversion: false)
     let htmlString: NSAttributedString?
     do {
         htmlString = try NSAttributedString(data: htmlData!, options: [NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType], documentAttributes: nil)
@@ -46,18 +46,13 @@ public func degreesToRadians(degrees: CGFloat) -> CGFloat {
     return degrees * CGFloat(M_PI / 180)
 }
 
-public func delay(delay:Double, closure:()->()) {
-    dispatch_after(
-        dispatch_time(
-            DISPATCH_TIME_NOW,
-            Int64(delay * Double(NSEC_PER_SEC))
-        ),
-        dispatch_get_main_queue(), closure)
+public func delay(delay:Double, closure: @escaping ()->()) {
+    DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(delay * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC), execute: closure)
 }
 
-public func imageFromURL(URL: String) -> UIImage {
-    let url = NSURL(string: URL)
-    let data = NSData(contentsOfURL: url!)
+public func imageFromURL(_ Url: String) -> UIImage {
+    let url = Foundation.URL(string: Url)
+    let data = try? Data(contentsOf: url!)
     return UIImage(data: data!)!
 }
 
@@ -70,13 +65,13 @@ public extension UIColor {
         var hex:   String = hex
         
         if hex.hasPrefix("#") {
-            let index = hex.startIndex.advancedBy(1)
-            hex         = hex.substringFromIndex(index)
+            let index = hex.index(hex.startIndex, offsetBy: 1)
+            hex         = hex.substring(from: index)
         }
-
-        let scanner = NSScanner(string: hex)
+        
+        let scanner = Scanner(string: hex)
         var hexValue: CUnsignedLongLong = 0
-        if scanner.scanHexLongLong(&hexValue) {
+        if scanner.scanHexInt64(&hexValue) {
             switch (hex.characters.count) {
             case 3:
                 red   = CGFloat((hexValue & 0xF00) >> 8)       / 15.0
@@ -121,18 +116,18 @@ public func UIColorFromRGB(rgbValue: UInt) -> UIColor {
 }
 
 public func stringFromDate(date: NSDate, format: String) -> String {
-    let dateFormatter = NSDateFormatter()
+    let dateFormatter = DateFormatter()
     dateFormatter.dateFormat = format
-    return dateFormatter.stringFromDate(date)
+    return dateFormatter.string(from: date as Date)
 }
 
-public func dateFromString(date: String, format: String) -> NSDate {
-    let dateFormatter = NSDateFormatter()
+public func dateFromString(date: String, format: String) -> Date {
+    let dateFormatter = DateFormatter()
     dateFormatter.dateFormat = format
-    if let date = dateFormatter.dateFromString(date) {
+    if let date = dateFormatter.date(from: date) {
         return date
     } else {
-        return NSDate(timeIntervalSince1970: 0)
+        return Date(timeIntervalSince1970: 0)
     }
 }
 
@@ -142,75 +137,126 @@ public func randomStringWithLength (len : Int) -> NSString {
     
     let randomString : NSMutableString = NSMutableString(capacity: len)
     
-    for _ in 0..<len {
+    for _ in 0 ..< len {
         let length = UInt32 (letters.length)
         let rand = arc4random_uniform(length)
-        randomString.appendFormat("%C", letters.characterAtIndex(Int(rand)))
+        randomString.appendFormat("%C", letters.character(at: Int(rand)))
     }
     
     return randomString
 }
 
-public func timeAgoSinceDate(date:NSDate, numericDates:Bool) -> String {
-    let calendar = NSCalendar.currentCalendar()
-    let unitFlags: NSCalendarUnit = [NSCalendarUnit.Minute, NSCalendarUnit.Hour, NSCalendarUnit.Day, NSCalendarUnit.WeekOfYear, NSCalendarUnit.Month, NSCalendarUnit.Year, NSCalendarUnit.Second]
-    let now = NSDate()
-    let earliest = now.earlierDate(date)
-    let latest = (earliest == now) ? date : now
-    let components: NSDateComponents = calendar.components(unitFlags, fromDate: earliest, toDate: latest, options: [])
+public func timeAgoSinceDate(date: Date, numericDates: Bool) -> String {
+    let calendar = Calendar.current
+    let unitFlags = Set<Calendar.Component>(arrayLiteral: Calendar.Component.minute, Calendar.Component.hour, Calendar.Component.day, Calendar.Component.weekOfYear, Calendar.Component.month, Calendar.Component.year, Calendar.Component.second)
+    let now = Date()
+    let dateComparison = now.compare(date)
+    var earliest: Date
+    var latest: Date
     
-    if (components.year >= 2) {
-        return "\(components.year)y"
-    } else if (components.year >= 1){
+    switch dateComparison {
+    case .orderedAscending:
+        earliest = now
+        latest = date
+    default:
+        earliest = date
+        latest = now
+    }
+    
+    let components: DateComponents = calendar.dateComponents(unitFlags, from: earliest, to: latest)
+    
+    guard
+        let year = components.year,
+        let month = components.month,
+        let weekOfYear = components.weekOfYear,
+        let day = components.day,
+        let hour = components.hour,
+        let minute = components.minute,
+        let second = components.second
+        else {
+        fatalError()
+    }
+    
+    if (year >= 2) {
+        return "\(year)y"
+    } else if (year >= 1) {
         if (numericDates){
             return "1y"
         } else {
             return "1y"
         }
-    } else if (components.month >= 2) {
-        return "\(components.month * 4)w"
-    } else if (components.month >= 1){
+    } else if (month >= 2) {
+        return "\(month * 4)w"
+    } else if (month >= 1) {
         if (numericDates){
             return "4w"
         } else {
             return "4w"
         }
-    } else if (components.weekOfYear >= 2) {
-        return "\(components.weekOfYear)w"
-    } else if (components.weekOfYear >= 1){
+    } else if (weekOfYear >= 2) {
+        return "\(weekOfYear)w"
+    } else if (weekOfYear >= 1){
         if (numericDates){
             return "1w"
         } else {
             return "1w"
         }
-    } else if (components.day >= 2) {
+    } else if (day >= 2) {
         return "\(components.day)d"
-    } else if (components.day >= 1){
+    } else if (day >= 1){
         if (numericDates){
             return "1d"
         } else {
             return "1d"
         }
-    } else if (components.hour >= 2) {
-        return "\(components.hour)h"
-    } else if (components.hour >= 1){
+    } else if (hour >= 2) {
+        return "\(hour)h"
+    } else if (hour >= 1){
         if (numericDates){
             return "1h"
         } else {
             return "1h"
         }
-    } else if (components.minute >= 2) {
-        return "\(components.minute)m"
-    } else if (components.minute >= 1){
+    } else if (minute >= 2) {
+        return "\(minute)m"
+    } else if (minute >= 1){
         if (numericDates){
             return "1m"
         } else {
             return "1m"
         }
-    } else if (components.second >= 3) {
-        return "\(components.second)s"
+    } else if (second >= 3) {
+        return "\(second)s"
     } else {
         return "now"
     }
     
+}
+
+extension UIImageView {
+    func setImage(url: URL, contentMode mode: UIViewContentMode = .scaleAspectFit, placeholderImage: UIImage?) {
+        contentMode = mode
+        URLSession.shared.dataTask(with: url) { (data, response, error) in
+            guard
+                let httpURLResponse = response as? HTTPURLResponse, httpURLResponse.statusCode == 200,
+                let mimeType = response?.mimeType, mimeType.hasPrefix("image"),
+                let data = data, error == nil,
+                let image = UIImage(data: data)
+                else {
+                    self.image = placeholderImage
+                    return
+            }
+            DispatchQueue.main.async() { () -> Void in
+                self.image = image
+                
+            }
+            }.resume()
+    }
+    func setImage(urlString: String, contentMode mode: UIViewContentMode = .scaleAspectFit, placeholderImage: UIImage?) {
+        guard let url = URL(string: urlString) else {
+            image = placeholderImage
+            return
+        }
+        setImage(url: url, contentMode: mode, placeholderImage: placeholderImage)
+    }
 }

--- a/SwiftRadio/Libraries/Spring/SoundPlayer.swift
+++ b/SwiftRadio/Libraries/Spring/SoundPlayer.swift
@@ -23,40 +23,38 @@
 import UIKit
 import AudioToolbox
 
-public class SoundPlayer: NSObject {
-
-    @IBInspectable var filename : String?
-    @IBInspectable var enabled : Bool = true
-
+struct SoundPlayer {
+    
+    static var filename : String?
+    static var enabled : Bool = true
+    
     private struct Internal {
-        static var cache = [NSURL:SystemSoundID]()
+        static var cache = [URL:SystemSoundID]()
     }
-
-    public func playSound(soundFile:String) {
-
+    
+    static func playSound(soundFile: String) {
+        
         if !enabled {
             return
         }
-
-        if let url = NSBundle.mainBundle().URLForResource(soundFile, withExtension: nil) {
-
+        
+        if let url = Bundle.main.url(forResource: soundFile, withExtension: nil) {
+            
             var soundID : SystemSoundID = Internal.cache[url] ?? 0
-
+            
             if soundID == 0 {
-                AudioServicesCreateSystemSoundID(url, &soundID)
+                AudioServicesCreateSystemSoundID(url as CFURL, &soundID)
                 Internal.cache[url] = soundID
             }
-
+            
             AudioServicesPlaySystemSound(soundID)
-
+            
         } else {
             print("Could not find sound file name `\(soundFile)`")
         }
     }
-
-    @IBAction public func play(sender: AnyObject?) {
-        if let filename = filename {
-            self.playSound(filename)
-        }
+    
+    static func play(file: String) {
+        self.playSound(soundFile: file)
     }
 }

--- a/SwiftRadio/Libraries/Spring/Spring.swift
+++ b/SwiftRadio/Libraries/Spring/Spring.swift
@@ -40,46 +40,46 @@ import UIKit
     var opacity: CGFloat { get set }
     var animateFrom: Bool { get set }
     var curve: String { get set }
-
+    
     // UIView
     var layer : CALayer { get }
     var transform : CGAffineTransform { get set }
     var alpha : CGFloat { get set }
     
     func animate()
-    func animateNext(completion: () -> ())
+    func animateNext(completion: @escaping () -> ())
     func animateTo()
-    func animateToNext(completion: () -> ())
+    func animateToNext(completion: @escaping () -> ())
 }
 
 public class Spring : NSObject {
-
+    
     private unowned var view : Springable
     private var shouldAnimateAfterActive = false
     private var shouldAnimateInLayoutSubviews = true
-
+    
     init(_ view: Springable) {
         self.view = view
         super.init()
         commonInit()
     }
-
+    
     func commonInit() {
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(Spring.didBecomeActiveNotification(_:)), name: UIApplicationDidBecomeActiveNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(Spring.didBecomeActiveNotification(_:)), name: NSNotification.Name.UIApplicationDidBecomeActive, object: nil)
     }
-
-    func didBecomeActiveNotification(notification: NSNotification) {
+    
+    func didBecomeActiveNotification(_ notification: NSNotification) {
         if shouldAnimateAfterActive {
             alpha = 0
             animate()
             shouldAnimateAfterActive = false
         }
     }
-
+    
     deinit {
-        NSNotificationCenter.defaultCenter().removeObserver(self, name: UIApplicationDidBecomeActiveNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: NSNotification.Name.UIApplicationDidBecomeActive, object: nil)
     }
-
+    
     private var autostart: Bool { set { self.view.autostart = newValue } get { return self.view.autostart }}
     private var autohide: Bool { set { self.view.autohide = newValue } get { return self.view.autohide }}
     private var animation: String { set { self.view.animation = newValue } get { return self.view.animation }}
@@ -97,12 +97,12 @@ public class Spring : NSObject {
     private var opacity: CGFloat { set { self.view.opacity = newValue } get { return self.view.opacity }}
     private var animateFrom: Bool { set { self.view.animateFrom = newValue } get { return self.view.animateFrom }}
     private var curve: String { set { self.view.curve = newValue } get { return self.view.curve }}
-
+    
     // UIView
     private var layer : CALayer { return view.layer }
     private var transform : CGAffineTransform { get { return view.transform } set { view.transform = newValue }}
     private var alpha: CGFloat { get { return view.alpha } set { view.alpha = newValue } }
-
+    
     public enum AnimationPreset: String {
         case SlideLeft = "slideLeft"
         case SlideRight = "slideRight"
@@ -132,7 +132,7 @@ public class Spring : NSObject {
         case Wobble = "wobble"
         case Swing = "swing"
     }
-
+    
     public enum AnimationCurve: String {
         case EaseIn = "easeIn"
         case EaseOut = "easeOut"
@@ -164,7 +164,7 @@ public class Spring : NSObject {
         case EaseOutBack = "easeOutBack"
         case EaseInOutBack = "easeInOutBack"
     }
-
+    
     func animatePreset() {
         alpha = 0.99
         if let animation = AnimationPreset(rawValue: animation) {
@@ -199,11 +199,11 @@ public class Spring : NSObject {
                 animation.keyPath = "opacity"
                 animation.fromValue = 1
                 animation.toValue = 0
-                animation.timingFunction = getTimingFunction(curve)
+                animation.timingFunction = getTimingFunction(curve: curve)
                 animation.duration = CFTimeInterval(duration)
                 animation.beginTime = CACurrentMediaTime() + CFTimeInterval(delay)
                 animation.autoreverses = true
-                layer.addAnimation(animation, forKey: "fade")
+                layer.add(animation, forKey: "fade")
             case .FadeInLeft:
                 opacity = 0
                 x = 300*force
@@ -234,94 +234,93 @@ public class Spring : NSObject {
                 animation.keyPath = "position.x"
                 animation.values = [0, 30*force, -30*force, 30*force, 0]
                 animation.keyTimes = [0, 0.2, 0.4, 0.6, 0.8, 1]
-                animation.timingFunction = getTimingFunction(curve)
+                animation.timingFunction = getTimingFunction(curve: curve)
                 animation.duration = CFTimeInterval(duration)
-                animation.additive = true
+                animation.isAdditive = true
                 animation.repeatCount = repeatCount
                 animation.beginTime = CACurrentMediaTime() + CFTimeInterval(delay)
-                layer.addAnimation(animation, forKey: "shake")
+                layer.add(animation, forKey: "shake")
             case .Pop:
                 let animation = CAKeyframeAnimation()
                 animation.keyPath = "transform.scale"
                 animation.values = [0, 0.2*force, -0.2*force, 0.2*force, 0]
                 animation.keyTimes = [0, 0.2, 0.4, 0.6, 0.8, 1]
-                animation.timingFunction = getTimingFunction(curve)
+                animation.timingFunction = getTimingFunction(curve: curve)
                 animation.duration = CFTimeInterval(duration)
-                animation.additive = true
+                animation.isAdditive = true
                 animation.repeatCount = repeatCount
                 animation.beginTime = CACurrentMediaTime() + CFTimeInterval(delay)
-                layer.addAnimation(animation, forKey: "pop")
+                layer.add(animation, forKey: "pop")
             case .FlipX:
                 rotate = 0
                 scaleX = 1
                 scaleY = 1
                 var perspective = CATransform3DIdentity
                 perspective.m34 = -1.0 / layer.frame.size.width/2
-
+                
                 let animation = CABasicAnimation()
                 animation.keyPath = "transform"
-                animation.fromValue = NSValue(CATransform3D:
-                    CATransform3DMakeRotation(0, 0, 0, 0))
-                animation.toValue = NSValue(CATransform3D:
+                animation.fromValue = NSValue(caTransform3D: CATransform3DMakeRotation(0, 0, 0, 0))
+                animation.toValue = NSValue(caTransform3D:
                     CATransform3DConcat(perspective, CATransform3DMakeRotation(CGFloat(M_PI), 0, 1, 0)))
                 animation.duration = CFTimeInterval(duration)
                 animation.beginTime = CACurrentMediaTime() + CFTimeInterval(delay)
-                animation.timingFunction = getTimingFunction(curve)
-                layer.addAnimation(animation, forKey: "3d")
+                animation.timingFunction = getTimingFunction(curve: curve)
+                layer.add(animation, forKey: "3d")
             case .FlipY:
                 var perspective = CATransform3DIdentity
                 perspective.m34 = -1.0 / layer.frame.size.width/2
-
+                
                 let animation = CABasicAnimation()
                 animation.keyPath = "transform"
-                animation.fromValue = NSValue(CATransform3D:
+                animation.fromValue = NSValue(caTransform3D:
                     CATransform3DMakeRotation(0, 0, 0, 0))
-                animation.toValue = NSValue(CATransform3D:
+                animation.toValue = NSValue(caTransform3D:
                     CATransform3DConcat(perspective,CATransform3DMakeRotation(CGFloat(M_PI), 1, 0, 0)))
                 animation.duration = CFTimeInterval(duration)
                 animation.beginTime = CACurrentMediaTime() + CFTimeInterval(delay)
-                animation.timingFunction = getTimingFunction(curve)
-                layer.addAnimation(animation, forKey: "3d")
+                animation.timingFunction = getTimingFunction(curve: curve)
+                layer.add(animation, forKey: "3d")
             case .Morph:
                 let morphX = CAKeyframeAnimation()
                 morphX.keyPath = "transform.scale.x"
                 morphX.values = [1, 1.3*force, 0.7, 1.3*force, 1]
                 morphX.keyTimes = [0, 0.2, 0.4, 0.6, 0.8, 1]
-                morphX.timingFunction = getTimingFunction(curve)
+                morphX.timingFunction = getTimingFunction(curve: curve)
                 morphX.duration = CFTimeInterval(duration)
                 morphX.repeatCount = repeatCount
                 morphX.beginTime = CACurrentMediaTime() + CFTimeInterval(delay)
-                layer.addAnimation(morphX, forKey: "morphX")
-
+                layer.add(morphX, forKey: "morphX")
+                
                 let morphY = CAKeyframeAnimation()
                 morphY.keyPath = "transform.scale.y"
                 morphY.values = [1, 0.7, 1.3*force, 0.7, 1]
                 morphY.keyTimes = [0, 0.2, 0.4, 0.6, 0.8, 1]
-                morphY.timingFunction = getTimingFunction(curve)
+                morphY.timingFunction = getTimingFunction(curve: curve)
                 morphY.duration = CFTimeInterval(duration)
                 morphY.repeatCount = repeatCount
                 morphY.beginTime = CACurrentMediaTime() + CFTimeInterval(delay)
-                layer.addAnimation(morphY, forKey: "morphY")
+                layer.add(morphY, forKey: "morphY")
             case .Squeeze:
                 let morphX = CAKeyframeAnimation()
                 morphX.keyPath = "transform.scale.x"
                 morphX.values = [1, 1.5*force, 0.5, 1.5*force, 1]
                 morphX.keyTimes = [0, 0.2, 0.4, 0.6, 0.8, 1]
-                morphX.timingFunction = getTimingFunction(curve)
+                morphX.timingFunction = getTimingFunction(curve: curve)
                 morphX.duration = CFTimeInterval(duration)
                 morphX.repeatCount = repeatCount
                 morphX.beginTime = CACurrentMediaTime() + CFTimeInterval(delay)
-                layer.addAnimation(morphX, forKey: "morphX")
-
+                layer.add(morphX, forKey: "morphX")
+                
                 let morphY = CAKeyframeAnimation()
                 morphY.keyPath = "transform.scale.y"
                 morphY.values = [1, 0.5, 1, 0.5, 1]
                 morphY.keyTimes = [0, 0.2, 0.4, 0.6, 0.8, 1]
-                morphY.timingFunction = getTimingFunction(curve)
+                morphY.timingFunction = getTimingFunction(curve: curve)
                 morphY.duration = CFTimeInterval(duration)
                 morphY.repeatCount = repeatCount
                 morphY.beginTime = CACurrentMediaTime() + CFTimeInterval(delay)
-                layer.addAnimation(morphY, forKey: "morphY")
+                layer.add(morphY, forKey: "morphY")
             case .Flash:
                 let animation = CABasicAnimation()
                 animation.keyPath = "opacity"
@@ -331,40 +330,40 @@ public class Spring : NSObject {
                 animation.repeatCount = repeatCount * 2.0
                 animation.autoreverses = true
                 animation.beginTime = CACurrentMediaTime() + CFTimeInterval(delay)
-                layer.addAnimation(animation, forKey: "flash")
+                layer.add(animation, forKey: "flash")
             case .Wobble:
                 let animation = CAKeyframeAnimation()
                 animation.keyPath = "transform.rotation"
                 animation.values = [0, 0.3*force, -0.3*force, 0.3*force, 0]
                 animation.keyTimes = [0, 0.2, 0.4, 0.6, 0.8, 1]
                 animation.duration = CFTimeInterval(duration)
-                animation.additive = true
+                animation.isAdditive = true
                 animation.beginTime = CACurrentMediaTime() + CFTimeInterval(delay)
-                layer.addAnimation(animation, forKey: "wobble")
-
+                layer.add(animation, forKey: "wobble")
+                
                 let x = CAKeyframeAnimation()
                 x.keyPath = "position.x"
                 x.values = [0, 30*force, -30*force, 30*force, 0]
                 x.keyTimes = [0, 0.2, 0.4, 0.6, 0.8, 1]
-                x.timingFunction = getTimingFunction(curve)
+                x.timingFunction = getTimingFunction(curve: curve)
                 x.duration = CFTimeInterval(duration)
-                x.additive = true
+                x.isAdditive = true
                 x.repeatCount = repeatCount
                 x.beginTime = CACurrentMediaTime() + CFTimeInterval(delay)
-                layer.addAnimation(x, forKey: "x")
+                layer.add(x, forKey: "x")
             case .Swing:
                 let animation = CAKeyframeAnimation()
                 animation.keyPath = "transform.rotation"
                 animation.values = [0, 0.3*force, -0.3*force, 0.3*force, 0]
                 animation.keyTimes = [0, 0.2, 0.4, 0.6, 0.8, 1]
                 animation.duration = CFTimeInterval(duration)
-                animation.additive = true
+                animation.isAdditive = true
                 animation.beginTime = CACurrentMediaTime() + CFTimeInterval(delay)
-                layer.addAnimation(animation, forKey: "swing")
+                layer.add(animation, forKey: "swing")
             }
         }
     }
-
+    
     func getTimingFunction(curve: String) -> CAMediaTimingFunction {
         if let curve = AnimationCurve(rawValue: curve) {
             switch curve {
@@ -401,40 +400,40 @@ public class Spring : NSObject {
         }
         return CAMediaTimingFunction(name: kCAMediaTimingFunctionDefault)
     }
-
+    
     func getAnimationOptions(curve: String) -> UIViewAnimationOptions {
         if let curve = AnimationCurve(rawValue: curve) {
             switch curve {
-            case .EaseIn: return UIViewAnimationOptions.CurveEaseIn
-            case .EaseOut: return UIViewAnimationOptions.CurveEaseOut
-            case .EaseInOut: return UIViewAnimationOptions.CurveEaseInOut
+            case .EaseIn: return UIViewAnimationOptions.curveEaseIn
+            case .EaseOut: return UIViewAnimationOptions.curveEaseOut
+            case .EaseInOut: return UIViewAnimationOptions()
             default: break
             }
         }
-        return UIViewAnimationOptions.CurveLinear
+        return UIViewAnimationOptions.curveLinear
     }
-
+    
     public func animate() {
         animateFrom = true
         animatePreset()
         setView {}
     }
-
-    public func animateNext(completion: () -> ()) {
+    
+    public func animateNext(completion: @escaping () -> ()) {
         animateFrom = true
         animatePreset()
         setView {
             completion()
         }
     }
-
+    
     public func animateTo() {
         animateFrom = false
         animatePreset()
         setView {}
     }
-
-    public func animateToNext(completion: () -> ()) {
+    
+    public func animateToNext(completion: @escaping () -> ()) {
         animateFrom = false
         animatePreset()
         setView {
@@ -452,7 +451,7 @@ public class Spring : NSObject {
         if shouldAnimateInLayoutSubviews {
             shouldAnimateInLayoutSubviews = false
             if autostart {
-                if UIApplication.sharedApplication().applicationState != .Active {
+                if UIApplication.shared.applicationState != .active {
                     shouldAnimateAfterActive = true
                     return
                 }
@@ -461,42 +460,42 @@ public class Spring : NSObject {
             }
         }
     }
-
-    func setView(completion: () -> ()) {
+    
+    func setView(completion: @escaping () -> ()) {
         if animateFrom {
-            let translate = CGAffineTransformMakeTranslation(self.x, self.y)
-            let scale = CGAffineTransformMakeScale(self.scaleX, self.scaleY)
-            let rotate = CGAffineTransformMakeRotation(self.rotate)
-            let translateAndScale = CGAffineTransformConcat(translate, scale)
-            self.transform = CGAffineTransformConcat(rotate, translateAndScale)
-
+            let translate = CGAffineTransform(translationX: self.x, y: self.y)
+            let scale = CGAffineTransform(scaleX: self.scaleX, y: self.scaleY)
+            let rotate = CGAffineTransform(rotationAngle: self.rotate)
+            let translateAndScale = translate.concatenating(scale)
+            self.transform = rotate.concatenating(translateAndScale)
+            
             self.alpha = self.opacity
         }
-
-        UIView.animateWithDuration( NSTimeInterval(duration),
-            delay: NSTimeInterval(delay),
-            usingSpringWithDamping: damping,
-            initialSpringVelocity: velocity,
-            options: [getAnimationOptions(curve), UIViewAnimationOptions.AllowUserInteraction],
-            animations: { [weak self] in
-            if let _self = self
-            {
-                if _self.animateFrom {
-                    _self.transform = CGAffineTransformIdentity
-                    _self.alpha = 1
-                }
-                else {
-                    let translate = CGAffineTransformMakeTranslation(_self.x, _self.y)
-                    let scale = CGAffineTransformMakeScale(_self.scaleX, _self.scaleY)
-                    let rotate = CGAffineTransformMakeRotation(_self.rotate)
-                    let translateAndScale = CGAffineTransformConcat(translate, scale)
-                    _self.transform = CGAffineTransformConcat(rotate, translateAndScale)
-                    
-                    _self.alpha = _self.opacity
-                }
-                
-            }
-            
+        
+        UIView.animate( withDuration: TimeInterval(duration),
+                        delay: TimeInterval(delay),
+                        usingSpringWithDamping: damping,
+                        initialSpringVelocity: velocity,
+                        options: [getAnimationOptions(curve: curve), UIViewAnimationOptions.allowUserInteraction],
+                        animations: { [weak self] in
+                            if let _self = self
+                            {
+                                if _self.animateFrom {
+                                    _self.transform = CGAffineTransform.identity
+                                    _self.alpha = 1
+                                }
+                                else {
+                                    let translate = CGAffineTransform(translationX: _self.x, y: _self.y)
+                                    let scale = CGAffineTransform(scaleX: _self.scaleX, y: _self.scaleY)
+                                    let rotate = CGAffineTransform(rotationAngle: _self.rotate)
+                                    let translateAndScale = translate.concatenating(scale)
+                                    _self.transform = rotate.concatenating(translateAndScale)
+                                    
+                                    _self.alpha = _self.opacity
+                                }
+                                
+                            }
+                            
             }, completion: { [weak self] finished in
                 
                 completion()
@@ -505,13 +504,13 @@ public class Spring : NSObject {
             })
         
     }
-
+    
     func reset() {
         x = 0
         y = 0
         opacity = 1
     }
-
+    
     func resetAll() {
         x = 0
         y = 0
@@ -526,5 +525,5 @@ public class Spring : NSObject {
         delay = 0
         duration = 0.7
     }
-
+    
 }

--- a/SwiftRadio/Libraries/Spring/SpringAnimation.swift
+++ b/SwiftRadio/Libraries/Spring/SpringAnimation.swift
@@ -23,9 +23,9 @@
 import UIKit
 
 @objc public class SpringAnimation: NSObject {
-    public class func spring(duration: NSTimeInterval, animations: () -> Void) {
-        UIView.animateWithDuration(
-            duration,
+    public class func spring(duration: TimeInterval, animations: @escaping () -> Void) {
+        UIView.animate(
+            withDuration: duration,
             delay: 0,
             usingSpringWithDamping: 0.7,
             initialSpringVelocity: 0.7,
@@ -37,11 +37,11 @@ import UIKit
         )
     }
 
-    public class func springEaseIn(duration: NSTimeInterval, animations: (() -> Void)!) {
-        UIView.animateWithDuration(
-            duration,
+    public class func springEaseIn(duration: TimeInterval, animations: (() -> Void)!) {
+        UIView.animate(
+            withDuration: duration,
             delay: 0,
-            options: .CurveEaseIn,
+            options: .curveEaseIn,
             animations: {
                 animations()
             },
@@ -49,42 +49,42 @@ import UIKit
         )
     }
 
-    public class func springEaseOut(duration: NSTimeInterval, animations: (() -> Void)!) {
-        UIView.animateWithDuration(
-            duration,
+    public class func springEaseOut(duration: TimeInterval, animations: (() -> Void)!) {
+        UIView.animate(
+            withDuration: duration,
             delay: 0,
-            options: .CurveEaseOut,
+            options: .curveEaseOut,
             animations: {
                 animations()
             }, completion: nil
         )
     }
 
-    public class func springEaseInOut(duration: NSTimeInterval, animations: (() -> Void)!) {
-        UIView.animateWithDuration(
-            duration,
+    public class func springEaseInOut(duration: TimeInterval, animations: (() -> Void)!) {
+        UIView.animate(
+            withDuration: duration,
             delay: 0,
-            options: .CurveEaseInOut,
+            options: UIViewAnimationOptions(),
             animations: {
                 animations()
             }, completion: nil
         )
     }
 
-    public class func springLinear(duration: NSTimeInterval, animations: (() -> Void)!) {
-        UIView.animateWithDuration(
-            duration,
+    public class func springLinear(duration: TimeInterval, animations: (() -> Void)!) {
+        UIView.animate(
+            withDuration: duration,
             delay: 0,
-            options: .CurveLinear,
+            options: .curveLinear,
             animations: {
                 animations()
             }, completion: nil
         )
     }
 
-    public class func springWithDelay(duration: NSTimeInterval, delay: NSTimeInterval, animations: (() -> Void)!) {
-        UIView.animateWithDuration(
-            duration,
+    public class func springWithDelay(duration: TimeInterval, delay: TimeInterval, animations: (() -> Void)!) {
+        UIView.animate(
+            withDuration: duration,
             delay: delay,
             usingSpringWithDamping: 0.7,
             initialSpringVelocity: 0.7,
@@ -95,9 +95,9 @@ import UIKit
         )
     }
 
-    public class func springWithCompletion(duration: NSTimeInterval, animations: (() -> Void)!, completion: (Bool -> Void)!) {
-        UIView.animateWithDuration(
-            duration,
+    public class func springWithCompletion(duration: TimeInterval, animations: (() -> Void)!, completion: ((Bool) -> Void)!) {
+        UIView.animate(
+            withDuration: duration,
             delay: 0,
             usingSpringWithDamping: 0.7,
             initialSpringVelocity: 0.7,

--- a/SwiftRadio/Libraries/Spring/SpringButton.swift
+++ b/SwiftRadio/Libraries/Spring/SpringButton.swift
@@ -22,7 +22,7 @@
 
 import UIKit
 
-public class SpringButton: UIButton, Springable {
+open class SpringButton: UIButton, Springable {
     @IBInspectable public var autostart: Bool = false
     @IBInspectable public var autohide: Bool = false
     @IBInspectable public var animation: String = ""
@@ -43,12 +43,12 @@ public class SpringButton: UIButton, Springable {
 
     lazy private var spring : Spring = Spring(self)
 
-    override public func awakeFromNib() {
+    override open func awakeFromNib() {
         super.awakeFromNib()
         self.spring.customAwakeFromNib()
     }
 
-    public override func layoutSubviews() {
+    open override func layoutSubviews() {
         super.layoutSubviews()
         spring.customLayoutSubviews()
     }
@@ -57,15 +57,15 @@ public class SpringButton: UIButton, Springable {
         self.spring.animate()
     }
 
-    public func animateNext(completion: () -> ()) {
-        self.spring.animateNext(completion)
+    public func animateNext(completion: @escaping () -> ()) {
+        self.spring.animateNext(completion: completion)
     }
 
     public func animateTo() {
         self.spring.animateTo()
     }
 
-    public func animateToNext(completion: () -> ()) {
-        self.spring.animateToNext(completion)
+    public func animateToNext(completion: @escaping () -> ()) {
+        self.spring.animateToNext(completion: completion)
     }
 }

--- a/SwiftRadio/Libraries/Spring/SpringImageView.swift
+++ b/SwiftRadio/Libraries/Spring/SpringImageView.swift
@@ -22,7 +22,7 @@
 
 import UIKit
 
-public class SpringImageView: UIImageView, Springable {
+open class SpringImageView: UIImageView, Springable {
     @IBInspectable public var autostart: Bool = false
     @IBInspectable public var autohide: Bool = false
     @IBInspectable public var animation: String = ""
@@ -43,12 +43,12 @@ public class SpringImageView: UIImageView, Springable {
 
     lazy private var spring : Spring = Spring(self)
 
-    override public func awakeFromNib() {
+    override open func awakeFromNib() {
         super.awakeFromNib()
         self.spring.customAwakeFromNib()
     }
 
-    public override func layoutSubviews() {
+    open override func layoutSubviews() {
         super.layoutSubviews()
         spring.customLayoutSubviews()
     }
@@ -57,16 +57,16 @@ public class SpringImageView: UIImageView, Springable {
         self.spring.animate()
     }
 
-    public func animateNext(completion: () -> ()) {
-        self.spring.animateNext(completion)
+    public func animateNext(completion: @escaping () -> ()) {
+        self.spring.animateNext(completion: completion)
     }
 
     public func animateTo() {
         self.spring.animateTo()
     }
 
-    public func animateToNext(completion: () -> ()) {
-        self.spring.animateToNext(completion)
+    public func animateToNext(completion: @escaping () -> ()) {
+        self.spring.animateToNext(completion: completion)
     }
 
 }

--- a/SwiftRadio/Libraries/Spring/SpringLabel.swift
+++ b/SwiftRadio/Libraries/Spring/SpringLabel.swift
@@ -22,7 +22,7 @@
 
 import UIKit
 
-public class SpringLabel: UILabel, Springable {
+open class SpringLabel: UILabel, Springable {
     @IBInspectable public var autostart: Bool = false
     @IBInspectable public var autohide: Bool = false
     @IBInspectable public var animation: String = ""
@@ -43,12 +43,12 @@ public class SpringLabel: UILabel, Springable {
 
     lazy private var spring : Spring = Spring(self)
 
-    override public func awakeFromNib() {
+    override open func awakeFromNib() {
         super.awakeFromNib()
         self.spring.customAwakeFromNib()
     }
 
-    public override func layoutSubviews() {
+    open override func layoutSubviews() {
         super.layoutSubviews()
         spring.customLayoutSubviews()
     }
@@ -57,16 +57,16 @@ public class SpringLabel: UILabel, Springable {
         self.spring.animate()
     }
 
-    public func animateNext(completion: () -> ()) {
-        self.spring.animateNext(completion)
+    public func animateNext(completion: @escaping () -> ()) {
+        self.spring.animateNext(completion: completion)
     }
 
     public func animateTo() {
         self.spring.animateTo()
     }
 
-    public func animateToNext(completion: () -> ()) {
-        self.spring.animateToNext(completion)
+    public func animateToNext(completion: @escaping () -> ()) {
+        self.spring.animateToNext(completion: completion)
     }
 
 }

--- a/SwiftRadio/Libraries/Spring/SpringTextField.swift
+++ b/SwiftRadio/Libraries/Spring/SpringTextField.swift
@@ -22,7 +22,7 @@
 
 import UIKit
 
-public class SpringTextField: UITextField, Springable {
+open class SpringTextField: UITextField, Springable {
     @IBInspectable public var autostart: Bool = false
     @IBInspectable public var autohide: Bool = false
     @IBInspectable public var animation: String = ""
@@ -43,12 +43,12 @@ public class SpringTextField: UITextField, Springable {
 
     lazy private var spring : Spring = Spring(self)
 
-    override public func awakeFromNib() {
+    override open func awakeFromNib() {
         super.awakeFromNib()
         self.spring.customAwakeFromNib()
     }
 
-    public override func layoutSubviews() {
+    open override func layoutSubviews() {
         super.layoutSubviews()
         spring.customLayoutSubviews()
     }
@@ -57,15 +57,15 @@ public class SpringTextField: UITextField, Springable {
         self.spring.animate()
     }
 
-    public func animateNext(completion: () -> ()) {
-        self.spring.animateNext(completion)
+    public func animateNext(completion: @escaping () -> ()) {
+        self.spring.animateNext(completion: completion)
     }
 
     public func animateTo() {
         self.spring.animateTo()
     }
 
-    public func animateToNext(completion: () -> ()) {
-        self.spring.animateToNext(completion)
+    public func animateToNext(completion: @escaping () -> ()) {
+        self.spring.animateToNext(completion: completion)
     }
 }

--- a/SwiftRadio/Libraries/Spring/SpringTextView.swift
+++ b/SwiftRadio/Libraries/Spring/SpringTextView.swift
@@ -22,7 +22,7 @@
 
 import UIKit
 
-public class SpringTextView: UITextView, Springable {
+open class SpringTextView: UITextView, Springable {
     @IBInspectable public var autostart: Bool = false
     @IBInspectable public var autohide: Bool = false
     @IBInspectable public var animation: String = ""
@@ -43,12 +43,12 @@ public class SpringTextView: UITextView, Springable {
 
     lazy private var spring : Spring = Spring(self)
 
-    override public func awakeFromNib() {
+    override open func awakeFromNib() {
         super.awakeFromNib()
         self.spring.customAwakeFromNib()
     }
 
-    public override func layoutSubviews() {
+    open override func layoutSubviews() {
         super.layoutSubviews()
         spring.customLayoutSubviews()
     }
@@ -57,16 +57,16 @@ public class SpringTextView: UITextView, Springable {
         self.spring.animate()
     }
 
-    public func animateNext(completion: () -> ()) {
-        self.spring.animateNext(completion)
+    public func animateNext(completion: @escaping () -> ()) {
+        self.spring.animateNext(completion: completion)
     }
 
     public func animateTo() {
         self.spring.animateTo()
     }
 
-    public func animateToNext(completion: () -> ()) {
-        self.spring.animateToNext(completion)
+    public func animateToNext(completion: @escaping () -> ()) {
+        self.spring.animateToNext(completion: completion)
     }
 
 }

--- a/SwiftRadio/Libraries/Spring/SpringView.swift
+++ b/SwiftRadio/Libraries/Spring/SpringView.swift
@@ -22,7 +22,7 @@
 
 import UIKit
 
-public class SpringView: UIView, Springable {
+open class SpringView: UIView, Springable {
     @IBInspectable public var autostart: Bool = false
     @IBInspectable public var autohide: Bool = false
     @IBInspectable public var animation: String = ""
@@ -43,12 +43,12 @@ public class SpringView: UIView, Springable {
 
     lazy private var spring : Spring = Spring(self)
 
-    override public func awakeFromNib() {
+    override open func awakeFromNib() {
         super.awakeFromNib()
         self.spring.customAwakeFromNib()
     }
 
-    public override func layoutSubviews() {
+    open override func layoutSubviews() {
         super.layoutSubviews()
         spring.customLayoutSubviews()
     }
@@ -57,15 +57,15 @@ public class SpringView: UIView, Springable {
         self.spring.animate()
     }
 
-    public func animateNext(completion: () -> ()) {
-        self.spring.animateNext(completion)
+    public func animateNext(completion: @escaping () -> ()) {
+        self.spring.animateNext(completion: completion)
     }
 
     public func animateTo() {
         self.spring.animateTo()
     }
 
-    public func animateToNext(completion: () -> ()) {
-        self.spring.animateToNext(completion)
+    public func animateToNext(completion: @escaping () -> ()) {
+        self.spring.animateToNext(completion: completion)
     }
 }

--- a/SwiftRadio/Libraries/Spring/TransitionManager.swift
+++ b/SwiftRadio/Libraries/Spring/TransitionManager.swift
@@ -27,20 +27,20 @@ public class TransitionManager: NSObject, UIViewControllerTransitioningDelegate,
     var isPresenting = true
     var duration = 0.3
     
-    public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
-        let container = transitionContext.containerView()
-        let fromView = transitionContext.viewForKey(UITransitionContextFromViewKey)!
-        let toView = transitionContext.viewForKey(UITransitionContextToViewKey)!
+    public func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+        let container = transitionContext.containerView
+        let fromView = transitionContext.view(forKey: UITransitionContextViewKey.from)!
+        let toView = transitionContext.view(forKey: UITransitionContextViewKey.to)!
         
         if isPresenting {
             toView.frame = container.bounds
-            toView.transform = CGAffineTransformMakeTranslation(0, container.frame.size.height)
+            toView.transform = CGAffineTransform(translationX: 0, y: container.frame.size.height)
             container.addSubview(fromView)
             container.addSubview(toView)
-            SpringAnimation.springEaseInOut(duration) {
-                fromView.transform = CGAffineTransformMakeScale(0.8, 0.8)
+            SpringAnimation.springEaseInOut(duration: duration) {
+                fromView.transform = CGAffineTransform(scaleX: 0.8, y: 0.8)
                 fromView.alpha = 0.5
-                toView.transform = CGAffineTransformIdentity
+                toView.transform = CGAffineTransform.identity
             }
         }
         else {
@@ -51,35 +51,35 @@ public class TransitionManager: NSObject, UIViewControllerTransitioningDelegate,
             // the same time take consideration of
             // previous transformation when presenting
             let transform = toView.transform
-            toView.transform = CGAffineTransformIdentity
+            toView.transform = CGAffineTransform.identity
             toView.frame = container.bounds
             toView.transform = transform
 
             container.addSubview(toView)
             container.addSubview(fromView)
 
-            SpringAnimation.springEaseInOut(duration) {
-                fromView.transform = CGAffineTransformMakeTranslation(0, fromView.frame.size.height)
-                toView.transform = CGAffineTransformIdentity
+            SpringAnimation.springEaseInOut(duration: duration) {
+                fromView.transform = CGAffineTransform(translationX: 0, y: fromView.frame.size.height)
+                toView.transform = CGAffineTransform.identity
                 toView.alpha = 1
             }
         }
         
-        delay(duration, closure: {
+        delay(delay: duration, closure: {
             transitionContext.completeTransition(true)
         })
     }
     
-    public func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
+    public func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
         return duration
     }
     
-    public func animationControllerForPresentedController(presented: UIViewController, presentingController presenting: UIViewController, sourceController source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+    public func animationController(forPresentedController presented: UIViewController, presenting: UIViewController, sourceController source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         isPresenting = true
         return self
     }
     
-    public func animationControllerForDismissedController(dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+    public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         isPresenting = false
         return self
     }

--- a/SwiftRadio/Libraries/Spring/TransitionZoom.swift
+++ b/SwiftRadio/Libraries/Spring/TransitionZoom.swift
@@ -27,22 +27,22 @@ public class TransitionZoom: NSObject, UIViewControllerTransitioningDelegate, UI
     var isPresenting = true
     var duration = 0.4
     
-    public func animateTransition(transitionContext: UIViewControllerContextTransitioning) {
-        let container = transitionContext.containerView()
-        let fromView = transitionContext.viewForKey(UITransitionContextFromViewKey)!
-        let toView = transitionContext.viewForKey(UITransitionContextToViewKey)!
+    public func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+        let container = transitionContext.containerView
+        let fromView = transitionContext.view(forKey: UITransitionContextViewKey.from)!
+        let toView = transitionContext.view(forKey: UITransitionContextViewKey.to)!
         
         if isPresenting {
             container.addSubview(fromView)
             container.addSubview(toView)
             
             toView.alpha = 0
-            toView.transform = CGAffineTransformMakeScale(2, 2)
+            toView.transform = CGAffineTransform(scaleX: 2, y: 2)
 
-            SpringAnimation.springEaseInOut(duration) {
-                fromView.transform = CGAffineTransformMakeScale(0.5, 0.5)
+            SpringAnimation.springEaseInOut(duration: duration) {
+                fromView.transform = CGAffineTransform(scaleX: 0.5, y: 0.5)
                 fromView.alpha = 0
-                toView.transform = CGAffineTransformIdentity
+                toView.transform = CGAffineTransform.identity
                 toView.alpha = 1
             }
         }
@@ -50,29 +50,29 @@ public class TransitionZoom: NSObject, UIViewControllerTransitioningDelegate, UI
             container.addSubview(toView)
             container.addSubview(fromView)
             
-            SpringAnimation.springEaseInOut(duration) {
-                fromView.transform = CGAffineTransformMakeScale(2, 2)
+            SpringAnimation.springEaseInOut(duration: duration) {
+                fromView.transform = CGAffineTransform(scaleX: 2, y: 2)
                 fromView.alpha = 0
-                toView.transform = CGAffineTransformMakeScale(1, 1)
+                toView.transform = CGAffineTransform(scaleX: 1, y: 1)
                 toView.alpha = 1
             }
         }
         
-        delay(duration, closure: {
+        delay(delay: duration, closure: {
             transitionContext.completeTransition(true)
         })
     }
     
-    public func transitionDuration(transitionContext: UIViewControllerContextTransitioning?) -> NSTimeInterval {
+    public func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
         return duration
     }
     
-    public func animationControllerForPresentedController(presented: UIViewController, presentingController presenting: UIViewController, sourceController source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+    public func animationController(forPresentedController presented: UIViewController, presenting: UIViewController, sourceController source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         isPresenting = true
         return self
     }
     
-    public func animationControllerForDismissedController(dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+    public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         isPresenting = false
         return self
     }

--- a/SwiftRadio/Libraries/Spring/UnwindSegue.swift
+++ b/SwiftRadio/Libraries/Spring/UnwindSegue.swift
@@ -23,5 +23,5 @@
 import UIKit
 
 public extension UIViewController {
-    @IBAction public func unwindToViewController (sender: UIStoryboardSegue){}
+    @IBAction public func unwindToViewController (_ segue: UIStoryboardSegue){}
 }

--- a/SwiftRadio/Libraries/SwiftyJSON.swift
+++ b/SwiftRadio/Libraries/SwiftyJSON.swift
@@ -1,6 +1,6 @@
 //  SwiftyJSON.swift
 //
-//  Copyright (c) 2014 Ruoyu Fu, Pinglin Tang
+//  Copyright (c) 2014 - 2016 Ruoyu Fu, Pinglin Tang
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -25,119 +25,213 @@ import Foundation
 // MARK: - Error
 
 ///Error domain
-public let ErrorDomain: String! = "SwiftyJSONErrorDomain"
+public let ErrorDomain: String = "SwiftyJSONErrorDomain"
 
 ///Error code
-public let ErrorUnsupportedType: Int! = 999
-public let ErrorIndexOutOfBounds: Int! = 900
-public let ErrorWrongType: Int! = 901
-public let ErrorNotExist: Int! = 500
+public let ErrorUnsupportedType: Int = 999
+public let ErrorIndexOutOfBounds: Int = 900
+public let ErrorWrongType: Int = 901
+public let ErrorNotExist: Int = 500
+public let ErrorInvalidJSON: Int = 490
 
 // MARK: - JSON Type
 
 /**
-JSON's type definitions.
+ JSON's type definitions.
 
-See http://tools.ietf.org/html/rfc7231#section-4.3
-*/
+ See http://www.json.org
+ */
 public enum Type :Int{
-    
-    case Number
-    case String
-    case Bool
-    case Array
-    case Dictionary
-    case Null
-    case Unknown
+
+    case number
+    case string
+    case bool
+    case array
+    case dictionary
+    case null
+    case unknown
 }
 
 // MARK: - JSON Base
-
 public struct JSON {
-    
+
     /**
-    Creates a JSON using the data.
-    
-    - parameter data:  The NSData used to convert to json.Top level object in data is an NSArray or NSDictionary
-    - parameter opt:   The JSON serialization reading options. `.AllowFragments` by default.
-    - parameter error: error The NSErrorPointer used to return the error. `nil` by default.
-    
-    - returns: The created JSON
-    */
-    public init(data:NSData, options opt: NSJSONReadingOptions = .AllowFragments, error: NSErrorPointer = nil) {
+     Creates a JSON using the data.
+
+     - parameter data:  The NSData used to convert to json.Top level object in data is an NSArray or NSDictionary
+     - parameter opt:   The JSON serialization reading options. `.AllowFragments` by default.
+     - parameter error: The NSErrorPointer used to return the error. `nil` by default.
+
+     - returns: The created JSON
+     */
+    public init(data: Data, options opt: JSONSerialization.ReadingOptions = .allowFragments, error: NSErrorPointer = nil) {
         do {
-            let object: AnyObject = try NSJSONSerialization.JSONObjectWithData(data, options: opt)
-            self.init(object)
+            let object: Any = try JSONSerialization.jsonObject(with: data, options: opt)
+            self.init(jsonObject: object)
         } catch let aError as NSError {
             if error != nil {
-                error.memory = aError
+                error?.pointee = aError
             }
+            self.init(jsonObject: NSNull())
+        }
+    }
+
+    /**
+     Creates a JSON object
+     - parameter object: the object
+     - note: this does not parse a `String` into JSON, instead use `init(parseJSON: String)`
+     - returns: the created JSON object
+     */
+    public init(_ object: Any) {
+        switch object {
+        case let object as [JSON] where object.count > 0:
+            self.init(array: object)
+        case let object as [String: JSON] where object.count > 0:
+            self.init(dictionary: object)
+        case let object as Data:
+            self.init(data: object)
+        default:
+            self.init(jsonObject: object)
+        }
+    }
+
+    /**
+     Parses the JSON string into a JSON object
+     - parameter json: the JSON string
+     - returns: the created JSON object
+     */
+    public init(parseJSON jsonString: String) {
+        if let data = jsonString.data(using: .utf8) {
+            self.init(data)
+        } else {
             self.init(NSNull())
         }
     }
-    
+
     /**
-    Creates a JSON using the object.
-    
-    - parameter object:  The object must have the following properties: All objects are NSString/String, NSNumber/Int/Float/Double/Bool, NSArray/Array, NSDictionary/Dictionary, or NSNull; All dictionary keys are NSStrings/String; NSNumbers are not NaN or infinity.
-    
-    - returns: The created JSON
-    */
-    public init(_ object: AnyObject) {
-        self.object = object
+     Creates a JSON from JSON string
+     - parameter string: Normal json string like '{"a":"b"}'
+
+     - returns: The created JSON
+     */
+    @available(*, deprecated: 3.2, message: "Use instead `init(parseJSON: )`")
+    public static func parse(json: String) -> JSON {
+        return json.data(using: String.Encoding.utf8)
+            .flatMap{ JSON(data: $0) } ?? JSON(NSNull())
     }
-    
+
     /**
-    Creates a JSON from a [JSON]
-    
-    - parameter jsonArray: A Swift array of JSON objects
-    
-    - returns: The created JSON
-    */
-    public init(_ jsonArray:[JSON]) {
-        self.init(jsonArray.map { $0.object })
+     Creates a JSON using the object.
+
+     - parameter object:  The object must have the following properties: All objects are NSString/String, NSNumber/Int/Float/Double/Bool, NSArray/Array, NSDictionary/Dictionary, or NSNull; All dictionary keys are NSStrings/String; NSNumbers are not NaN or infinity.
+
+     - returns: The created JSON
+     */
+    private init(jsonObject: Any) {
+        self.object = jsonObject
     }
-    
+
     /**
-    Creates a JSON from a [String: JSON]
-    
-    :param: jsonDictionary A Swift dictionary of JSON objects
-    
-    :returns: The created JSON
-    */
-    public init(_ jsonDictionary:[String: JSON]) {
-        var dictionary = [String: AnyObject]()
-        for (key, json) in jsonDictionary {
-            dictionary[key] = json.object
+     Creates a JSON from a [JSON]
+
+     - parameter jsonArray: A Swift array of JSON objects
+
+     - returns: The created JSON
+     */
+    private init(array: [JSON]) {
+        self.init(array.map { $0.object })
+    }
+
+    /**
+     Creates a JSON from a [String: JSON]
+
+     - parameter jsonDictionary: A Swift dictionary of JSON objects
+
+     - returns: The created JSON
+     */
+    private init(dictionary: [String: JSON]) {
+        var newDictionary = [String: Any](minimumCapacity: dictionary.count)
+        for (key, json) in dictionary {
+            newDictionary[key] = json.object
         }
-        self.init(dictionary)
+
+        self.init(newDictionary)
     }
     
-    /// Private object
-    private var rawArray: [AnyObject] = []
-    private var rawDictionary: [String : AnyObject] = [:]
-    private var rawString: String = ""
-    private var rawNumber: NSNumber = 0
-    private var rawNull: NSNull = NSNull()
-    /// Private type
-    private var _type: Type = .Null
-    /// prviate error
-    private var _error: NSError? = nil
+    /**
+     Merges another JSON into this JSON, whereas primitive values which are not present in this JSON are getting added, 
+     present values getting overwritten, array values getting appended and nested JSONs getting merged the same way.
+ 
+     - parameter other: The JSON which gets merged into this JSON
+     - throws `ErrorWrongType` if the other JSONs differs in type on the top level.
+     */
+    public mutating func merge(with other: JSON) throws {
+        try self.merge(with: other, typecheck: true)
+    }
     
+    /**
+     Merges another JSON into this JSON and returns a new JSON, whereas primitive values which are not present in this JSON are getting added,
+     present values getting overwritten, array values getting appended and nested JSONS getting merged the same way.
+     
+     - parameter other: The JSON which gets merged into this JSON
+     - returns: New merged JSON
+     - throws `ErrorWrongType` if the other JSONs differs in type on the top level.
+     */
+    public func merged(with other: JSON) throws -> JSON {
+        var merged = self
+        try merged.merge(with: other, typecheck: true)
+        return merged
+    }
+    
+    // Private woker function which does the actual merging
+    // Typecheck is set to true for the first recursion level to prevent total override of the source JSON
+    private mutating func merge(with other: JSON, typecheck: Bool) throws {
+        if self.type == other.type {
+            switch self.type {
+            case .dictionary:
+                for (key, _) in other {
+                    try self[key].merge(with: other[key], typecheck: false)
+                }
+            case .array:
+                self = JSON(self.arrayValue + other.arrayValue)
+            default:
+                self = other
+            }
+        } else {
+            if typecheck {
+                throw NSError(domain: ErrorDomain, code: ErrorWrongType, userInfo: [NSLocalizedDescriptionKey: "Couldn't merge, because the JSONs differ in type on top level."])
+            } else {
+                self = other
+            }
+        }
+    }
+
+    /// Private object
+    fileprivate var rawArray: [Any] = []
+    fileprivate var rawDictionary: [String : Any] = [:]
+    fileprivate var rawString: String = ""
+    fileprivate var rawNumber: NSNumber = 0
+    fileprivate var rawNull: NSNull = NSNull()
+    fileprivate var rawBool: Bool = false
+    /// Private type
+    fileprivate var _type: Type = .null
+    /// prviate error
+    fileprivate var _error: NSError? = nil
+
     /// Object in JSON
-    public var object: AnyObject {
+    public var object: Any {
         get {
             switch self.type {
-            case .Array:
+            case .array:
                 return self.rawArray
-            case .Dictionary:
+            case .dictionary:
                 return self.rawDictionary
-            case .String:
+            case .string:
                 return self.rawString
-            case .Number:
+            case .number:
                 return self.rawNumber
-            case .Bool:
-                return self.rawNumber
+            case .bool:
+                return self.rawBool
             default:
                 return self.rawNull
             }
@@ -147,276 +241,175 @@ public struct JSON {
             switch newValue {
             case let number as NSNumber:
                 if number.isBool {
-                    _type = .Bool
+                    _type = .bool
+                    self.rawBool = number.boolValue
                 } else {
-                    _type = .Number
+                    _type = .number
+                    self.rawNumber = number
                 }
-                self.rawNumber = number
-            case  let string as String:
-                _type = .String
+            case let string as String:
+                _type = .string
                 self.rawString = string
-            case  _ as NSNull:
-                _type = .Null
-            case let array as [AnyObject]:
-                _type = .Array
+            case _ as NSNull:
+                _type = .null
+            case _ as [JSON]:
+				_type = .array
+			case nil:
+				_type = .null
+            case let array as [Any]:
+                _type = .array
                 self.rawArray = array
-            case let dictionary as [String : AnyObject]:
-                _type = .Dictionary
+            case let dictionary as [String : Any]:
+                _type = .dictionary
                 self.rawDictionary = dictionary
             default:
-                _type = .Unknown
+                _type = .unknown
                 _error = NSError(domain: ErrorDomain, code: ErrorUnsupportedType, userInfo: [NSLocalizedDescriptionKey: "It is a unsupported type"])
             }
         }
     }
-    
-    /// json type
+
+    /// JSON type
     public var type: Type { get { return _type } }
-    
+
     /// Error in JSON
     public var error: NSError? { get { return self._error } }
-    
-    /// The static null json
-    @available(*, unavailable, renamed="null")
+
+    /// The static null JSON
+    @available(*, unavailable, renamed:"null")
     public static var nullJSON: JSON { get { return null } }
     public static var null: JSON { get { return JSON(NSNull()) } }
 }
 
-// MARK: - CollectionType, SequenceType, Indexable
-extension JSON : Swift.CollectionType, Swift.SequenceType, Swift.Indexable {
-    
-    public typealias Generator = JSONGenerator
-    
-    public typealias Index = JSONIndex
-    
-    public var startIndex: JSON.Index {
-        switch self.type {
-        case .Array:
-            return JSONIndex(arrayIndex: self.rawArray.startIndex)
-        case .Dictionary:
-            return JSONIndex(dictionaryIndex: self.rawDictionary.startIndex)
+public enum Index<T: Any>: Comparable
+{
+    case array(Int)
+    case dictionary(DictionaryIndex<String, T>)
+    case null
+
+    static public func ==(lhs: Index, rhs: Index) -> Bool {
+        switch (lhs, rhs) {
+        case (.array(let left), .array(let right)):
+            return left == right
+        case (.dictionary(let left), .dictionary(let right)):
+            return left == right
+        case (.null, .null): return true
         default:
-            return JSONIndex()
+            return false
         }
     }
-    
-    public var endIndex: JSON.Index {
-        switch self.type {
-        case .Array:
-            return JSONIndex(arrayIndex: self.rawArray.endIndex)
-        case .Dictionary:
-            return JSONIndex(dictionaryIndex: self.rawDictionary.endIndex)
+
+    static public func <(lhs: Index, rhs: Index) -> Bool {
+        switch (lhs, rhs) {
+        case (.array(let left), .array(let right)):
+            return left < right
+        case (.dictionary(let left), .dictionary(let right)):
+            return left < right
         default:
-            return JSONIndex()
+            return false
         }
     }
-    
-    public subscript (position: JSON.Index) -> JSON.Generator.Element {
-        switch self.type {
-        case .Array:
-            return (String(position.arrayIndex), JSON(self.rawArray[position.arrayIndex!]))
-        case .Dictionary:
-            let (key, value) = self.rawDictionary[position.dictionaryIndex!]
+}
+
+public typealias JSONIndex = Index<JSON>
+public typealias JSONRawIndex = Index<Any>
+
+
+extension JSON: Collection
+{
+
+    public typealias Index = JSONRawIndex
+
+    public var startIndex: Index
+    {
+        switch type
+        {
+        case .array:
+            return .array(rawArray.startIndex)
+        case .dictionary:
+            return .dictionary(rawDictionary.startIndex)
+        default:
+            return .null
+        }
+    }
+
+    public var endIndex: Index
+    {
+        switch type
+        {
+        case .array:
+            return .array(rawArray.endIndex)
+        case .dictionary:
+            return .dictionary(rawDictionary.endIndex)
+        default:
+            return .null
+        }
+    }
+
+    public func index(after i: Index) -> Index
+    {
+        switch i
+        {
+        case .array(let idx):
+            return .array(rawArray.index(after: idx))
+        case .dictionary(let idx):
+            return .dictionary(rawDictionary.index(after: idx))
+        default:
+            return .null
+        }
+
+    }
+
+    public subscript (position: Index) -> (String, JSON)
+    {
+        switch position
+        {
+        case .array(let idx):
+            return (String(idx), JSON(self.rawArray[idx]))
+        case .dictionary(let idx):
+            let (key, value) = self.rawDictionary[idx]
             return (key, JSON(value))
         default:
             return ("", JSON.null)
         }
     }
-    
-    /// If `type` is `.Array` or `.Dictionary`, return `array.empty` or `dictonary.empty` otherwise return `false`.
-    public var isEmpty: Bool {
-        get {
-            switch self.type {
-            case .Array:
-                return self.rawArray.isEmpty
-            case .Dictionary:
-                return self.rawDictionary.isEmpty
-            default:
-                return true
-            }
-        }
-    }
-    
-    /// If `type` is `.Array` or `.Dictionary`, return `array.count` or `dictonary.count` otherwise return `0`.
-    public var count: Int {
-        switch self.type {
-        case .Array:
-            return self.rawArray.count
-        case .Dictionary:
-            return self.rawDictionary.count
-        default:
-            return 0
-        }
-    }
-    
-    public func underestimateCount() -> Int {
-        switch self.type {
-        case .Array:
-            return self.rawArray.underestimateCount()
-        case .Dictionary:
-            return self.rawDictionary.underestimateCount()
-        default:
-            return 0
-        }
-    }
-    
-    /**
-    If `type` is `.Array` or `.Dictionary`, return a generator over the elements like `Array` or `Dictionary`, otherwise return a generator over empty.
-    
-    - returns: Return a *generator* over the elements of JSON.
-    */
-    public func generate() -> JSON.Generator {
-        return JSON.Generator(self)
-    }
-}
 
-public struct JSONIndex: ForwardIndexType, _Incrementable, Equatable, Comparable {
-    
-    let arrayIndex: Int?
-    let dictionaryIndex: DictionaryIndex<String, AnyObject>?
-    
-    let type: Type
-    
-    init(){
-        self.arrayIndex = nil
-        self.dictionaryIndex = nil
-        self.type = .Unknown
-    }
-    
-    init(arrayIndex: Int) {
-        self.arrayIndex = arrayIndex
-        self.dictionaryIndex = nil
-        self.type = .Array
-    }
-    
-    init(dictionaryIndex: DictionaryIndex<String, AnyObject>) {
-        self.arrayIndex = nil
-        self.dictionaryIndex = dictionaryIndex
-        self.type = .Dictionary
-    }
-    
-    public func successor() -> JSONIndex {
-        switch self.type {
-        case .Array:
-            return JSONIndex(arrayIndex: self.arrayIndex!.successor())
-        case .Dictionary:
-            return JSONIndex(dictionaryIndex: self.dictionaryIndex!.successor())
-        default:
-            return JSONIndex()
-        }
-    }
-}
 
-public func ==(lhs: JSONIndex, rhs: JSONIndex) -> Bool {
-    switch (lhs.type, rhs.type) {
-    case (.Array, .Array):
-        return lhs.arrayIndex == rhs.arrayIndex
-    case (.Dictionary, .Dictionary):
-        return lhs.dictionaryIndex == rhs.dictionaryIndex
-    default:
-        return false
-    }
-}
-
-public func <(lhs: JSONIndex, rhs: JSONIndex) -> Bool {
-    switch (lhs.type, rhs.type) {
-    case (.Array, .Array):
-        return lhs.arrayIndex < rhs.arrayIndex
-    case (.Dictionary, .Dictionary):
-        return lhs.dictionaryIndex < rhs.dictionaryIndex
-    default:
-        return false
-    }
-}
-
-public func <=(lhs: JSONIndex, rhs: JSONIndex) -> Bool {
-    switch (lhs.type, rhs.type) {
-    case (.Array, .Array):
-        return lhs.arrayIndex <= rhs.arrayIndex
-    case (.Dictionary, .Dictionary):
-        return lhs.dictionaryIndex <= rhs.dictionaryIndex
-    default:
-        return false
-    }
-}
-
-public func >=(lhs: JSONIndex, rhs: JSONIndex) -> Bool {
-    switch (lhs.type, rhs.type) {
-    case (.Array, .Array):
-        return lhs.arrayIndex >= rhs.arrayIndex
-    case (.Dictionary, .Dictionary):
-        return lhs.dictionaryIndex >= rhs.dictionaryIndex
-    default:
-        return false
-    }
-}
-
-public func >(lhs: JSONIndex, rhs: JSONIndex) -> Bool {
-    switch (lhs.type, rhs.type) {
-    case (.Array, .Array):
-        return lhs.arrayIndex > rhs.arrayIndex
-    case (.Dictionary, .Dictionary):
-        return lhs.dictionaryIndex > rhs.dictionaryIndex
-    default:
-        return false
-    }
-}
-
-public struct JSONGenerator : GeneratorType {
-    
-    public typealias Element = (String, JSON)
-    
-    private let type: Type
-    private var dictionayGenerate: DictionaryGenerator<String, AnyObject>?
-    private var arrayGenerate: IndexingGenerator<[AnyObject]>?
-    private var arrayIndex: Int = 0
-    
-    init(_ json: JSON) {
-        self.type = json.type
-        if type == .Array {
-            self.arrayGenerate = json.rawArray.generate()
-        }else {
-            self.dictionayGenerate = json.rawDictionary.generate()
-        }
-    }
-    
-    public mutating func next() -> JSONGenerator.Element? {
-        switch self.type {
-        case .Array:
-            if let o = self.arrayGenerate!.next() {
-                return (String(self.arrayIndex += 1), JSON(o))
-            } else {
-                return nil
-            }
-        case .Dictionary:
-            if let (k, v): (String, AnyObject) = self.dictionayGenerate!.next() {
-                return (k, JSON(v))
-            } else {
-                return nil
-            }
-        default:
-            return nil
-        }
-    }
 }
 
 // MARK: - Subscript
 
 /**
-*  To mark both String and Int can be used in subscript.
-*/
-public protocol JSONSubscriptType {}
+ *  To mark both String and Int can be used in subscript.
+ */
+public enum JSONKey
+{
+    case index(Int)
+    case key(String)
+}
 
-extension Int: JSONSubscriptType {}
+public protocol JSONSubscriptType {
+    var jsonKey:JSONKey { get }
+}
 
-extension String: JSONSubscriptType {}
+extension Int: JSONSubscriptType {
+    public var jsonKey:JSONKey {
+        return JSONKey.index(self)
+    }
+}
+
+extension String: JSONSubscriptType {
+    public var jsonKey:JSONKey {
+        return JSONKey.key(self)
+    }
+}
 
 extension JSON {
-    
-    /// If `type` is `.Array`, return json which's object is `array[index]`, otherwise return null json with error.
-    private subscript(index index: Int) -> JSON {
+
+    /// If `type` is `.Array`, return json whose object is `array[index]`, otherwise return null json with error.
+    fileprivate subscript(index index: Int) -> JSON {
         get {
-            if self.type != .Array {
+            if self.type != .array {
                 var r = JSON.null
                 r._error = self._error ?? NSError(domain: ErrorDomain, code: ErrorWrongType, userInfo: [NSLocalizedDescriptionKey: "Array[\(index)] failure, It is not an array"])
                 return r
@@ -429,19 +422,19 @@ extension JSON {
             }
         }
         set {
-            if self.type == .Array {
+            if self.type == .array {
                 if self.rawArray.count > index && newValue.error == nil {
                     self.rawArray[index] = newValue.object
                 }
             }
         }
     }
-    
-    /// If `type` is `.Dictionary`, return json which's object is `dictionary[key]` , otherwise return null json with error.
-    private subscript(key key: String) -> JSON {
+
+    /// If `type` is `.Dictionary`, return json whose object is `dictionary[key]` , otherwise return null json with error.
+    fileprivate subscript(key key: String) -> JSON {
         get {
             var r = JSON.null
-            if self.type == .Dictionary {
+            if self.type == .dictionary {
                 if let o = self.rawDictionary[key] {
                     r = JSON(o)
                 } else {
@@ -453,43 +446,41 @@ extension JSON {
             return r
         }
         set {
-            if self.type == .Dictionary && newValue.error == nil {
+            if self.type == .dictionary && newValue.error == nil {
                 self.rawDictionary[key] = newValue.object
             }
         }
     }
-    
+
     /// If `sub` is `Int`, return `subscript(index:)`; If `sub` is `String`,  return `subscript(key:)`.
-    private subscript(sub sub: JSONSubscriptType) -> JSON {
+    fileprivate subscript(sub sub: JSONSubscriptType) -> JSON {
         get {
-            if sub is String {
-                return self[key:sub as! String]
-            } else {
-                return self[index:sub as! Int]
+            switch sub.jsonKey {
+            case .index(let index): return self[index: index]
+            case .key(let key): return self[key: key]
             }
         }
         set {
-            if sub is String {
-                self[key:sub as! String] = newValue
-            } else {
-                self[index:sub as! Int] = newValue
+            switch sub.jsonKey {
+            case .index(let index): self[index: index] = newValue
+            case .key(let key): self[key: key] = newValue
             }
         }
     }
-    
+
     /**
-    Find a json in the complex data structuresby using the Int/String's array.
-    
-    - parameter path: The target json's path. Example:
-    
-    let json = JSON[data]
-    let path = [9,"list","person","name"]
-    let name = json[path]
-    
-    The same as: let name = json[9]["list"]["person"]["name"]
-    
-    - returns: Return a json found by the path or a null json with error
-    */
+     Find a json in the complex data structures by using array of Int and/or String as path.
+
+     - parameter path: The target json's path. Example:
+
+     let json = JSON[data]
+     let path = [9,"list","person","name"]
+     let name = json[path]
+
+     The same as: let name = json[9]["list"]["person"]["name"]
+
+     - returns: Return a json found by the path or a null json with error
+     */
     public subscript(path: [JSONSubscriptType]) -> JSON {
         get {
             return path.reduce(self) { $0[sub: $1] }
@@ -501,25 +492,25 @@ extension JSON {
             case 1:
                 self[sub:path[0]].object = newValue.object
             default:
-                var aPath = path; aPath.removeAtIndex(0)
+                var aPath = path; aPath.remove(at: 0)
                 var nextJSON = self[sub: path[0]]
                 nextJSON[aPath] = newValue
                 self[sub: path[0]] = nextJSON
             }
         }
     }
-    
+
     /**
-    Find a json in the complex data structuresby using the Int/String's array.
-    
-    - parameter path: The target json's path. Example:
-    
-    let name = json[9,"list","person","name"]
-    
-    The same as: let name = json[9]["list"]["person"]["name"]
-    
-    - returns: Return a json found by the path or a null json with error
-    */
+     Find a json in the complex data structures by using array of Int and/or String as path.
+
+     - parameter path: The target json's path. Example:
+
+     let name = json[9,"list","person","name"]
+
+     The same as: let name = json[9]["list"]["person"]["name"]
+
+     - returns: Return a json found by the path or a null json with error
+     */
     public subscript(path: JSONSubscriptType...) -> JSON {
         get {
             return self[path]
@@ -532,103 +523,222 @@ extension JSON {
 
 // MARK: - LiteralConvertible
 
-extension JSON: Swift.StringLiteralConvertible {
-    
+extension JSON: Swift.ExpressibleByStringLiteral {
+
     public init(stringLiteral value: StringLiteralType) {
-        self.init(value)
+        self.init(value as Any)
     }
-    
+
     public init(extendedGraphemeClusterLiteral value: StringLiteralType) {
-        self.init(value)
+        self.init(value as Any)
     }
-    
+
     public init(unicodeScalarLiteral value: StringLiteralType) {
-        self.init(value)
+        self.init(value as Any)
     }
 }
 
-extension JSON: Swift.IntegerLiteralConvertible {
-    
+extension JSON: Swift.ExpressibleByIntegerLiteral {
+
     public init(integerLiteral value: IntegerLiteralType) {
-        self.init(value)
+        self.init(value as Any)
     }
 }
 
-extension JSON: Swift.BooleanLiteralConvertible {
-    
+extension JSON: Swift.ExpressibleByBooleanLiteral {
+
     public init(booleanLiteral value: BooleanLiteralType) {
-        self.init(value)
+        self.init(value as Any)
     }
 }
 
-extension JSON: Swift.FloatLiteralConvertible {
-    
+extension JSON: Swift.ExpressibleByFloatLiteral {
+
     public init(floatLiteral value: FloatLiteralType) {
-        self.init(value)
+        self.init(value as Any)
     }
 }
 
-extension JSON: Swift.DictionaryLiteralConvertible {
-    
-    public init(dictionaryLiteral elements: (String, AnyObject)...) {
-        self.init(elements.reduce([String : AnyObject]()){(dictionary: [String : AnyObject], element:(String, AnyObject)) -> [String : AnyObject] in
-            var d = dictionary
-            d[element.0] = element.1
-            return d
-            })
+extension JSON: Swift.ExpressibleByDictionaryLiteral {
+    public init(dictionaryLiteral elements: (String, Any)...) {
+        let array = elements
+        self.init(dictionaryLiteral: array)
+    }
+
+    public init(dictionaryLiteral elements: [(String, Any)]) {
+        let jsonFromDictionaryLiteral: ([String : Any]) -> JSON = { dictionary in
+            let initializeElement = Array(dictionary.keys).flatMap { key -> (String, Any)? in
+                if let value = dictionary[key] {
+                    return (key, value)
+                }
+                return nil
+            }
+            return JSON(dictionaryLiteral: initializeElement)
+        }
+
+        var dict = [String : Any](minimumCapacity: elements.count)
+
+        for element in elements {
+            let elementToSet: Any
+            if let json = element.1 as? JSON {
+                elementToSet = json.object
+            } else if let jsonArray = element.1 as? [JSON] {
+                elementToSet = JSON(jsonArray).object
+            } else if let dictionary = element.1 as? [String : Any] {
+                elementToSet = jsonFromDictionaryLiteral(dictionary).object
+            } else if let dictArray = element.1 as? [[String : Any]] {
+                let jsonArray = dictArray.map { jsonFromDictionaryLiteral($0) }
+                elementToSet = JSON(jsonArray).object
+            } else {
+                elementToSet = element.1
+            }
+            dict[element.0] = elementToSet
+        }
+
+        self.init(dict)
     }
 }
 
-extension JSON: Swift.ArrayLiteralConvertible {
-    
-    public init(arrayLiteral elements: AnyObject...) {
-        self.init(elements)
+extension JSON: Swift.ExpressibleByArrayLiteral {
+
+    public init(arrayLiteral elements: Any...) {
+        self.init(elements as Any)
     }
 }
 
-extension JSON: Swift.NilLiteralConvertible {
-    
+extension JSON: Swift.ExpressibleByNilLiteral {
+
+    @available(*, deprecated, message: "use JSON.null instead. Will be removed in future versions")
     public init(nilLiteral: ()) {
-        self.init(NSNull())
+        self.init(NSNull() as Any)
     }
 }
 
 // MARK: - Raw
 
 extension JSON: Swift.RawRepresentable {
-    
-    public init?(rawValue: AnyObject) {
-        if JSON(rawValue).type == .Unknown {
+
+    public init?(rawValue: Any) {
+        if JSON(rawValue).type == .unknown {
             return nil
         } else {
             self.init(rawValue)
         }
     }
-    
-    public var rawValue: AnyObject {
+
+    public var rawValue: Any {
         return self.object
     }
-    
-    public func rawData(options opt: NSJSONWritingOptions = NSJSONWritingOptions(rawValue: 0)) throws -> NSData {
-        return try NSJSONSerialization.dataWithJSONObject(self.object, options: opt)
-    }
-    
-    public func rawString(encoding: UInt = NSUTF8StringEncoding, options opt: NSJSONWritingOptions = .PrettyPrinted) -> String? {
+
+    public func rawData(options opt: JSONSerialization.WritingOptions = JSONSerialization.WritingOptions(rawValue: 0)) throws -> Data {
+        guard JSONSerialization.isValidJSONObject(self.object) else {
+            throw NSError(domain: ErrorDomain, code: ErrorInvalidJSON, userInfo: [NSLocalizedDescriptionKey: "JSON is invalid"])
+        }
+
+        return try JSONSerialization.data(withJSONObject: self.object, options: opt)
+	}
+	
+	public func rawString(_ encoding: String.Encoding = .utf8, options opt: JSONSerialization.WritingOptions = .prettyPrinted) -> String? {
+		do {
+			return try _rawString(encoding, options: [.jsonSerialization: opt])
+		} catch {
+			print("Could not serialize object to JSON because:", error.localizedDescription)
+			return nil
+		}
+	}
+
+	public func rawString(options: [writtingOptionsKeys: Any]) -> String? {
+		let encoding = options[.encoding] as? String.Encoding ?? String.Encoding.utf8
+		let maxObjectDepth = options[.maxObjextDepth] as? Int ?? 10
+		do {
+			return try _rawString(encoding, options: options, maxObjectDepth: maxObjectDepth)
+		} catch {
+			print("Could not serialize object to JSON because:", error.localizedDescription)
+			return nil
+		}
+	}
+
+	private func _rawString(
+		_ encoding: String.Encoding = .utf8,
+		options: [writtingOptionsKeys: Any],
+		maxObjectDepth: Int = 10
+	) throws -> String? {
+        if (maxObjectDepth < 0) {
+            throw NSError(domain: ErrorDomain, code: ErrorInvalidJSON, userInfo: [NSLocalizedDescriptionKey: "Element too deep. Increase maxObjectDepth and make sure there is no reference loop"])
+        }
         switch self.type {
-        case .Array, .Dictionary:
+		case .dictionary:
+			do {
+				if !(options[.castNilToNSNull] as? Bool ?? false) {
+					let jsonOption = options[.jsonSerialization] as? JSONSerialization.WritingOptions ?? JSONSerialization.WritingOptions.prettyPrinted
+					let data = try self.rawData(options: jsonOption)
+					return String(data: data, encoding: encoding)
+				}
+
+				guard let dict = self.object as? [String: Any?] else {
+					return nil
+				}
+				let body = try dict.keys.map { key throws -> String in
+					guard let value = dict[key] else {
+						return "\"\(key)\": null"
+					}
+					guard let unwrappedValue = value else {
+						return "\"\(key)\": null"
+					}
+
+					let nestedValue = JSON(unwrappedValue)
+					guard let nestedString = try nestedValue._rawString(encoding, options: options, maxObjectDepth: maxObjectDepth - 1) else {
+						throw NSError(domain: ErrorDomain, code: ErrorInvalidJSON, userInfo: [NSLocalizedDescriptionKey: "Could not serialize nested JSON"])
+					}
+					if nestedValue.type == .string {
+						return "\"\(key)\": \"\(nestedString.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\""))\""
+					} else {
+						return "\"\(key)\": \(nestedString)"
+					}
+				}
+
+				return "{\(body.joined(separator: ","))}"
+			} catch _ {
+				return nil
+			}
+		case .array:
             do {
-                let data = try self.rawData(options: opt)
-                return NSString(data: data, encoding: encoding) as? String
+				if !(options[.castNilToNSNull] as? Bool ?? false) {
+					let jsonOption = options[.jsonSerialization] as? JSONSerialization.WritingOptions ?? JSONSerialization.WritingOptions.prettyPrinted
+					let data = try self.rawData(options: jsonOption)
+					return String(data: data, encoding: encoding)
+				}
+
+                guard let array = self.object as? [Any?] else {
+                    return nil
+                }
+                let body = try array.map { value throws -> String in
+                    guard let unwrappedValue = value else {
+                        return "null"
+                    }
+
+                    let nestedValue = JSON(unwrappedValue)
+                    guard let nestedString = try nestedValue._rawString(encoding, options: options, maxObjectDepth: maxObjectDepth - 1) else {
+                        throw NSError(domain: ErrorDomain, code: ErrorInvalidJSON, userInfo: [NSLocalizedDescriptionKey: "Could not serialize nested JSON"])
+                    }
+                    if nestedValue.type == .string {
+                        return "\"\(nestedString.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\""))\""
+                    } else {
+                        return nestedString
+                    }
+                }
+
+                return "[\(body.joined(separator: ","))]"
             } catch _ {
                 return nil
             }
-        case .String:
+        case .string:
             return self.rawString
-        case .Number:
+        case .number:
             return self.rawNumber.stringValue
-        case .Bool:
-            return self.rawNumber.boolValue.description
-        case .Null:
+        case .bool:
+            return self.rawBool.description
+        case .null:
             return "null"
         default:
             return nil
@@ -638,16 +748,16 @@ extension JSON: Swift.RawRepresentable {
 
 // MARK: - Printable, DebugPrintable
 
-extension JSON: Swift.Printable, Swift.DebugPrintable {
-    
+extension JSON: Swift.CustomStringConvertible, Swift.CustomDebugStringConvertible {
+
     public var description: String {
-        if let string = self.rawString(options:.PrettyPrinted) {
+        if let string = self.rawString(options:.prettyPrinted) {
             return string
         } else {
             return "unknown"
         }
     }
-    
+
     public var debugDescription: String {
         return description
     }
@@ -656,30 +766,30 @@ extension JSON: Swift.Printable, Swift.DebugPrintable {
 // MARK: - Array
 
 extension JSON {
-    
+
     //Optional [JSON]
     public var array: [JSON]? {
         get {
-            if self.type == .Array {
+            if self.type == .array {
                 return self.rawArray.map{ JSON($0) }
             } else {
                 return nil
             }
         }
     }
-    
+
     //Non-optional [JSON]
     public var arrayValue: [JSON] {
         get {
             return self.array ?? []
         }
     }
-    
-    //Optional [AnyObject]
-    public var arrayObject: [AnyObject]? {
+
+    //Optional [Any]
+    public var arrayObject: [Any]? {
         get {
             switch self.type {
-            case .Array:
+            case .array:
                 return self.rawArray
             default:
                 return nil
@@ -687,7 +797,7 @@ extension JSON {
         }
         set {
             if let array = newValue {
-                self.object = array
+                self.object = array as Any
             } else {
                 self.object = NSNull()
             }
@@ -698,30 +808,31 @@ extension JSON {
 // MARK: - Dictionary
 
 extension JSON {
-    
+
     //Optional [String : JSON]
     public var dictionary: [String : JSON]? {
-        if self.type == .Dictionary {
-            return self.rawDictionary.reduce([String : JSON]()) { (dictionary: [String : JSON], element: (String, AnyObject)) -> [String : JSON] in
-                var d = dictionary
-                d[element.0] = JSON(element.1)
-                return d
+        if self.type == .dictionary {
+            var d = [String : JSON](minimumCapacity: rawDictionary.count)
+            for (key, value) in rawDictionary {
+                d[key] = JSON(value)
             }
+            return d
         } else {
             return nil
         }
     }
-    
+
     //Non-optional [String : JSON]
     public var dictionaryValue: [String : JSON] {
         return self.dictionary ?? [:]
     }
-    
-    //Optional [String : AnyObject]
-    public var dictionaryObject: [String : AnyObject]? {
+
+    //Optional [String : Any]
+
+    public var dictionaryObject: [String : Any]? {
         get {
             switch self.type {
-            case .Dictionary:
+            case .dictionary:
                 return self.rawDictionary
             default:
                 return nil
@@ -729,7 +840,7 @@ extension JSON {
         }
         set {
             if let v = newValue {
-                self.object = v
+                self.object = v as Any
             } else {
                 self.object = NSNull()
             }
@@ -739,39 +850,45 @@ extension JSON {
 
 // MARK: - Bool
 
-extension JSON: Swift.BooleanType {
-    
+extension JSON { // : Swift.Bool
+
     //Optional bool
     public var bool: Bool? {
         get {
             switch self.type {
-            case .Bool:
-                return self.rawNumber.boolValue
+            case .bool:
+                return self.rawBool
             default:
                 return nil
             }
         }
         set {
-            if newValue != nil {
-                self.object = NSNumber(bool: newValue!)
+            if let newValue = newValue {
+                self.object = newValue as Bool
             } else {
                 self.object = NSNull()
             }
         }
     }
-    
+
     //Non-optional bool
     public var boolValue: Bool {
         get {
             switch self.type {
-            case .Bool, .Number, .String:
-                return self.object.boolValue
+            case .bool:
+                return self.rawBool
+            case .number:
+                return self.rawNumber.boolValue
+            case .string:
+                return ["true", "y", "t"].contains() { (truthyString) in
+                    return self.rawString.caseInsensitiveCompare(truthyString) == .orderedSame
+                }
             default:
                 return false
             }
         }
         set {
-            self.object = NSNumber(bool: newValue)
+            self.object = newValue
         }
     }
 }
@@ -779,36 +896,36 @@ extension JSON: Swift.BooleanType {
 // MARK: - String
 
 extension JSON {
-    
+
     //Optional string
     public var string: String? {
         get {
             switch self.type {
-            case .String:
+            case .string:
                 return self.object as? String
             default:
                 return nil
             }
         }
         set {
-            if newValue != nil {
-                self.object = NSString(string:newValue!)
+            if let newValue = newValue {
+                self.object = NSString(string:newValue)
             } else {
                 self.object = NSNull()
             }
         }
     }
-    
+
     //Non-optional string
     public var stringValue: String {
         get {
             switch self.type {
-            case .String:
-                return self.object as! String
-            case .Number:
-                return self.object.stringValue
-            case .Bool:
-                return (self.object as! Bool).description
+            case .string:
+                return self.object as? String ?? ""
+            case .number:
+                return self.rawNumber.stringValue
+            case .bool:
+                return (self.object as? Bool).map { String($0) } ?? ""
             default:
                 return ""
             }
@@ -821,13 +938,15 @@ extension JSON {
 
 // MARK: - Number
 extension JSON {
-    
+
     //Optional number
     public var number: NSNumber? {
         get {
             switch self.type {
-            case .Number, .Bool:
+            case .number:
                 return self.rawNumber
+            case .bool:
+                return NSNumber(value: self.rawBool ? 1 : 0)
             default:
                 return nil
             }
@@ -836,23 +955,23 @@ extension JSON {
             self.object = newValue ?? NSNull()
         }
     }
-    
+
     //Non-optional number
     public var numberValue: NSNumber {
         get {
             switch self.type {
-            case .String:
-                let scanner = NSScanner(string: self.object as! String)
-                if scanner.scanDouble(nil){
-                    if (scanner.atEnd) {
-                        return NSNumber(double:(self.object as! NSString).doubleValue)
-                    }
+            case .string:
+                let decimal = NSDecimalNumber(string: self.object as? String)
+                if decimal == NSDecimalNumber.notANumber {  // indicates parse error
+                    return NSDecimalNumber.zero
                 }
-                return NSNumber(double: 0.0)
-            case .Number, .Bool:
-                return self.object as! NSNumber
+                return decimal
+            case .number:
+                return self.object as? NSNumber ?? NSNumber(value: 0)
+            case .bool:
+                return NSNumber(value: self.rawBool ? 1 : 0)
             default:
-                return NSNumber(double: 0.0)
+                return NSNumber(value: 0.0)
             }
         }
         set {
@@ -863,11 +982,11 @@ extension JSON {
 
 //MARK: - Null
 extension JSON {
-    
+
     public var null: NSNull? {
         get {
             switch self.type {
-            case .Null:
+            case .null:
                 return self.rawNull
             default:
                 return nil
@@ -877,18 +996,30 @@ extension JSON {
             self.object = NSNull()
         }
     }
+    public func exists() -> Bool{
+        if let errorValue = error, errorValue.code == ErrorNotExist ||
+            errorValue.code == ErrorIndexOutOfBounds ||
+            errorValue.code == ErrorWrongType {
+                return false
+        }
+        return true
+    }
 }
 
 //MARK: - URL
 extension JSON {
-    
+
     //Optional URL
-    public var URL: NSURL? {
+    public var url: URL? {
         get {
             switch self.type {
-            case .String:
-                if let encodedString_ = self.rawString.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLQueryAllowedCharacterSet()) {
-                    return NSURL(string: encodedString_)
+            case .string:
+                // Check for existing percent escapes first to prevent double-escaping of % character
+                if let _ = self.rawString.range(of: "%[0-9A-Fa-f]{2}", options: .regularExpression, range: nil, locale: nil) {
+                    return Foundation.URL(string: self.rawString)
+                } else if let encodedString_ = self.rawString.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed) {
+                    // We have to use `Foundation.URL` otherwise it conflicts with the variable name.
+                    return Foundation.URL(string: encodedString_)
                 } else {
                     return nil
                 }
@@ -905,268 +1036,273 @@ extension JSON {
 // MARK: - Int, Double, Float, Int8, Int16, Int32, Int64
 
 extension JSON {
-    
+
     public var double: Double? {
         get {
             return self.number?.doubleValue
         }
         set {
-            if newValue != nil {
-                self.object = NSNumber(double: newValue!)
+            if let newValue = newValue {
+                self.object = NSNumber(value: newValue)
             } else {
                 self.object = NSNull()
             }
         }
     }
-    
+
     public var doubleValue: Double {
         get {
             return self.numberValue.doubleValue
         }
         set {
-            self.object = NSNumber(double: newValue)
+            self.object = NSNumber(value: newValue)
         }
     }
-    
+
     public var float: Float? {
         get {
             return self.number?.floatValue
         }
         set {
-            if newValue != nil {
-                self.object = NSNumber(float: newValue!)
+            if let newValue = newValue {
+                self.object = NSNumber(value: newValue)
             } else {
                 self.object = NSNull()
             }
         }
     }
-    
+
     public var floatValue: Float {
         get {
             return self.numberValue.floatValue
         }
         set {
-            self.object = NSNumber(float: newValue)
+            self.object = NSNumber(value: newValue)
         }
     }
-    
-    public var int: Int? {
-        get {
-            return self.number?.longValue
-        }
-        set {
-            if newValue != nil {
-                self.object = NSNumber(integer: newValue!)
-            } else {
-                self.object = NSNull()
-            }
-        }
-    }
-    
-    public var intValue: Int {
-        get {
-            return self.numberValue.integerValue
-        }
-        set {
-            self.object = NSNumber(integer: newValue)
-        }
-    }
-    
-    public var uInt: UInt? {
-        get {
-            return self.number?.unsignedLongValue
-        }
-        set {
-            if newValue != nil {
-                self.object = NSNumber(unsignedLong: newValue!)
-            } else {
-                self.object = NSNull()
-            }
-        }
-    }
-    
-    public var uIntValue: UInt {
-        get {
-            return self.numberValue.unsignedLongValue
-        }
-        set {
-            self.object = NSNumber(unsignedLong: newValue)
-        }
-    }
-    
-    public var int8: Int8? {
-        get {
-            return self.number?.charValue
-        }
-        set {
-            if newValue != nil {
-                self.object = NSNumber(char: newValue!)
-            } else {
-                self.object =  NSNull()
-            }
-        }
-    }
-    
-    public var int8Value: Int8 {
-        get {
-            return self.numberValue.charValue
-        }
-        set {
-            self.object = NSNumber(char: newValue)
-        }
-    }
-    
-    public var uInt8: UInt8? {
-        get {
-            return self.number?.unsignedCharValue
-        }
-        set {
-            if newValue != nil {
-                self.object = NSNumber(unsignedChar: newValue!)
-            } else {
-                self.object =  NSNull()
-            }
-        }
-    }
-    
-    public var uInt8Value: UInt8 {
-        get {
-            return self.numberValue.unsignedCharValue
-        }
-        set {
-            self.object = NSNumber(unsignedChar: newValue)
-        }
-    }
-    
-    public var int16: Int16? {
-        get {
-            return self.number?.shortValue
-        }
-        set {
-            if newValue != nil {
-                self.object = NSNumber(short: newValue!)
-            } else {
-                self.object =  NSNull()
-            }
-        }
-    }
-    
-    public var int16Value: Int16 {
-        get {
-            return self.numberValue.shortValue
-        }
-        set {
-            self.object = NSNumber(short: newValue)
-        }
-    }
-    
-    public var uInt16: UInt16? {
-        get {
-            return self.number?.unsignedShortValue
-        }
-        set {
-            if newValue != nil {
-                self.object = NSNumber(unsignedShort: newValue!)
-            } else {
-                self.object =  NSNull()
-            }
-        }
-    }
-    
-    public var uInt16Value: UInt16 {
-        get {
-            return self.numberValue.unsignedShortValue
-        }
-        set {
-            self.object = NSNumber(unsignedShort: newValue)
-        }
-    }
-    
-    public var int32: Int32? {
-        get {
+
+    public var int: Int?
+    {
+        get
+        {
             return self.number?.intValue
         }
-        set {
-            if newValue != nil {
-                self.object = NSNumber(int: newValue!)
-            } else {
-                self.object =  NSNull()
+        set
+        {
+            if let newValue = newValue
+            {
+                self.object = NSNumber(value: newValue)
+            } else
+            {
+                self.object = NSNull()
             }
         }
     }
-    
-    public var int32Value: Int32 {
+
+    public var intValue: Int {
         get {
             return self.numberValue.intValue
         }
         set {
-            self.object = NSNumber(int: newValue)
+            self.object = NSNumber(value: newValue)
         }
     }
-    
+
+    public var uInt: UInt? {
+        get {
+            return self.number?.uintValue
+        }
+        set {
+            if let newValue = newValue {
+                self.object = NSNumber(value: newValue)
+            } else {
+                self.object = NSNull()
+            }
+        }
+    }
+
+    public var uIntValue: UInt {
+        get {
+            return self.numberValue.uintValue
+        }
+        set {
+            self.object = NSNumber(value: newValue)
+        }
+    }
+
+    public var int8: Int8? {
+        get {
+            return self.number?.int8Value
+        }
+        set {
+            if let newValue = newValue {
+                self.object = NSNumber(value: Int(newValue))
+            } else {
+                self.object =  NSNull()
+            }
+        }
+    }
+
+    public var int8Value: Int8 {
+        get {
+            return self.numberValue.int8Value
+        }
+        set {
+            self.object = NSNumber(value: Int(newValue))
+        }
+    }
+
+    public var uInt8: UInt8? {
+        get {
+            return self.number?.uint8Value
+        }
+        set {
+            if let newValue = newValue {
+                self.object = NSNumber(value: newValue)
+            } else {
+                self.object =  NSNull()
+            }
+        }
+    }
+
+    public var uInt8Value: UInt8 {
+        get {
+            return self.numberValue.uint8Value
+        }
+        set {
+            self.object = NSNumber(value: newValue)
+        }
+    }
+
+    public var int16: Int16? {
+        get {
+            return self.number?.int16Value
+        }
+        set {
+            if let newValue = newValue {
+                self.object = NSNumber(value: newValue)
+            } else {
+                self.object =  NSNull()
+            }
+        }
+    }
+
+    public var int16Value: Int16 {
+        get {
+            return self.numberValue.int16Value
+        }
+        set {
+            self.object = NSNumber(value: newValue)
+        }
+    }
+
+    public var uInt16: UInt16? {
+        get {
+            return self.number?.uint16Value
+        }
+        set {
+            if let newValue = newValue {
+                self.object = NSNumber(value: newValue)
+            } else {
+                self.object =  NSNull()
+            }
+        }
+    }
+
+    public var uInt16Value: UInt16 {
+        get {
+            return self.numberValue.uint16Value
+        }
+        set {
+            self.object = NSNumber(value: newValue)
+        }
+    }
+
+    public var int32: Int32? {
+        get {
+            return self.number?.int32Value
+        }
+        set {
+            if let newValue = newValue {
+                self.object = NSNumber(value: newValue)
+            } else {
+                self.object =  NSNull()
+            }
+        }
+    }
+
+    public var int32Value: Int32 {
+        get {
+            return self.numberValue.int32Value
+        }
+        set {
+            self.object = NSNumber(value: newValue)
+        }
+    }
+
     public var uInt32: UInt32? {
         get {
-            return self.number?.unsignedIntValue
+            return self.number?.uint32Value
         }
         set {
-            if newValue != nil {
-                self.object = NSNumber(unsignedInt: newValue!)
+            if let newValue = newValue {
+                self.object = NSNumber(value: newValue)
             } else {
                 self.object =  NSNull()
             }
         }
     }
-    
+
     public var uInt32Value: UInt32 {
         get {
-            return self.numberValue.unsignedIntValue
+            return self.numberValue.uint32Value
         }
         set {
-            self.object = NSNumber(unsignedInt: newValue)
+            self.object = NSNumber(value: newValue)
         }
     }
-    
+
     public var int64: Int64? {
         get {
-            return self.number?.longLongValue
+            return self.number?.int64Value
         }
         set {
-            if newValue != nil {
-                self.object = NSNumber(longLong: newValue!)
+            if let newValue = newValue {
+                self.object = NSNumber(value: newValue)
             } else {
                 self.object =  NSNull()
             }
         }
     }
-    
+
     public var int64Value: Int64 {
         get {
-            return self.numberValue.longLongValue
+            return self.numberValue.int64Value
         }
         set {
-            self.object = NSNumber(longLong: newValue)
+            self.object = NSNumber(value: newValue)
         }
     }
-    
+
     public var uInt64: UInt64? {
         get {
-            return self.number?.unsignedLongLongValue
+            return self.number?.uint64Value
         }
         set {
-            if newValue != nil {
-                self.object = NSNumber(unsignedLongLong: newValue!)
+            if let newValue = newValue {
+                self.object = NSNumber(value: newValue)
             } else {
                 self.object =  NSNull()
             }
         }
     }
-    
+
     public var uInt64Value: UInt64 {
         get {
-            return self.numberValue.unsignedLongLongValue
+            return self.numberValue.uint64Value
         }
         set {
-            self.object = NSNumber(unsignedLongLong: newValue)
+            self.object = NSNumber(value: newValue)
         }
     }
 }
@@ -1175,19 +1311,19 @@ extension JSON {
 extension JSON : Swift.Comparable {}
 
 public func ==(lhs: JSON, rhs: JSON) -> Bool {
-    
+
     switch (lhs.type, rhs.type) {
-    case (.Number, .Number):
+    case (.number, .number):
         return lhs.rawNumber == rhs.rawNumber
-    case (.String, .String):
+    case (.string, .string):
         return lhs.rawString == rhs.rawString
-    case (.Bool, .Bool):
-        return lhs.rawNumber.boolValue == rhs.rawNumber.boolValue
-    case (.Array, .Array):
+    case (.bool, .bool):
+        return lhs.rawBool == rhs.rawBool
+    case (.array, .array):
         return lhs.rawArray as NSArray == rhs.rawArray as NSArray
-    case (.Dictionary, .Dictionary):
+    case (.dictionary, .dictionary):
         return lhs.rawDictionary as NSDictionary == rhs.rawDictionary as NSDictionary
-    case (.Null, .Null):
+    case (.null, .null):
         return true
     default:
         return false
@@ -1195,19 +1331,19 @@ public func ==(lhs: JSON, rhs: JSON) -> Bool {
 }
 
 public func <=(lhs: JSON, rhs: JSON) -> Bool {
-    
+
     switch (lhs.type, rhs.type) {
-    case (.Number, .Number):
+    case (.number, .number):
         return lhs.rawNumber <= rhs.rawNumber
-    case (.String, .String):
+    case (.string, .string):
         return lhs.rawString <= rhs.rawString
-    case (.Bool, .Bool):
-        return lhs.rawNumber.boolValue == rhs.rawNumber.boolValue
-    case (.Array, .Array):
+    case (.bool, .bool):
+        return lhs.rawBool == rhs.rawBool
+    case (.array, .array):
         return lhs.rawArray as NSArray == rhs.rawArray as NSArray
-    case (.Dictionary, .Dictionary):
+    case (.dictionary, .dictionary):
         return lhs.rawDictionary as NSDictionary == rhs.rawDictionary as NSDictionary
-    case (.Null, .Null):
+    case (.null, .null):
         return true
     default:
         return false
@@ -1215,19 +1351,19 @@ public func <=(lhs: JSON, rhs: JSON) -> Bool {
 }
 
 public func >=(lhs: JSON, rhs: JSON) -> Bool {
-    
+
     switch (lhs.type, rhs.type) {
-    case (.Number, .Number):
+    case (.number, .number):
         return lhs.rawNumber >= rhs.rawNumber
-    case (.String, .String):
+    case (.string, .string):
         return lhs.rawString >= rhs.rawString
-    case (.Bool, .Bool):
-        return lhs.rawNumber.boolValue == rhs.rawNumber.boolValue
-    case (.Array, .Array):
+    case (.bool, .bool):
+        return lhs.rawBool == rhs.rawBool
+    case (.array, .array):
         return lhs.rawArray as NSArray == rhs.rawArray as NSArray
-    case (.Dictionary, .Dictionary):
+    case (.dictionary, .dictionary):
         return lhs.rawDictionary as NSDictionary == rhs.rawDictionary as NSDictionary
-    case (.Null, .Null):
+    case (.null, .null):
         return true
     default:
         return false
@@ -1235,11 +1371,11 @@ public func >=(lhs: JSON, rhs: JSON) -> Bool {
 }
 
 public func >(lhs: JSON, rhs: JSON) -> Bool {
-    
+
     switch (lhs.type, rhs.type) {
-    case (.Number, .Number):
+    case (.number, .number):
         return lhs.rawNumber > rhs.rawNumber
-    case (.String, .String):
+    case (.string, .string):
         return lhs.rawString > rhs.rawString
     default:
         return false
@@ -1247,31 +1383,30 @@ public func >(lhs: JSON, rhs: JSON) -> Bool {
 }
 
 public func <(lhs: JSON, rhs: JSON) -> Bool {
-    
+
     switch (lhs.type, rhs.type) {
-    case (.Number, .Number):
+    case (.number, .number):
         return lhs.rawNumber < rhs.rawNumber
-    case (.String, .String):
+    case (.string, .string):
         return lhs.rawString < rhs.rawString
     default:
         return false
     }
 }
 
-private let trueNumber = NSNumber(bool: true)
-private let falseNumber = NSNumber(bool: false)
-private let trueObjCType = String.fromCString(trueNumber.objCType)
-private let falseObjCType = String.fromCString(falseNumber.objCType)
+private let trueNumber = NSNumber(value: true)
+private let falseNumber = NSNumber(value: false)
+private let trueObjCType = String(cString: trueNumber.objCType)
+private let falseObjCType = String(cString: falseNumber.objCType)
 
 // MARK: - NSNumber: Comparable
 
-extension NSNumber: Swift.Comparable {
+extension NSNumber {
     var isBool:Bool {
         get {
-            let objCType = String.fromCString(self.objCType)
-            if (self.compare(trueNumber) == NSComparisonResult.OrderedSame && objCType == trueObjCType)
-                || (self.compare(falseNumber) == NSComparisonResult.OrderedSame && objCType == falseObjCType){
-                    return true
+            let objCType = String(cString: self.objCType)
+            if (self.compare(trueNumber) == .orderedSame && objCType == trueObjCType) || (self.compare(falseNumber) == .orderedSame && objCType == falseObjCType){
+                return true
             } else {
                 return false
             }
@@ -1279,65 +1414,72 @@ extension NSNumber: Swift.Comparable {
     }
 }
 
-public func ==(lhs: NSNumber, rhs: NSNumber) -> Bool {
+func ==(lhs: NSNumber, rhs: NSNumber) -> Bool {
     switch (lhs.isBool, rhs.isBool) {
     case (false, true):
         return false
     case (true, false):
         return false
     default:
-        return lhs.compare(rhs) == NSComparisonResult.OrderedSame
+        return lhs.compare(rhs) == .orderedSame
     }
 }
 
-public func !=(lhs: NSNumber, rhs: NSNumber) -> Bool {
+func !=(lhs: NSNumber, rhs: NSNumber) -> Bool {
     return !(lhs == rhs)
 }
 
-public func <(lhs: NSNumber, rhs: NSNumber) -> Bool {
-    
+func <(lhs: NSNumber, rhs: NSNumber) -> Bool {
+
     switch (lhs.isBool, rhs.isBool) {
     case (false, true):
         return false
     case (true, false):
         return false
     default:
-        return lhs.compare(rhs) == NSComparisonResult.OrderedAscending
+        return lhs.compare(rhs) == .orderedAscending
     }
 }
 
-public func >(lhs: NSNumber, rhs: NSNumber) -> Bool {
-    
+func >(lhs: NSNumber, rhs: NSNumber) -> Bool {
+
     switch (lhs.isBool, rhs.isBool) {
     case (false, true):
         return false
     case (true, false):
         return false
     default:
-        return lhs.compare(rhs) == NSComparisonResult.OrderedDescending
+        return lhs.compare(rhs) == ComparisonResult.orderedDescending
     }
 }
 
-public func <=(lhs: NSNumber, rhs: NSNumber) -> Bool {
-    
+func <=(lhs: NSNumber, rhs: NSNumber) -> Bool {
+
     switch (lhs.isBool, rhs.isBool) {
     case (false, true):
         return false
     case (true, false):
         return false
     default:
-        return lhs.compare(rhs) != NSComparisonResult.OrderedDescending
+        return lhs.compare(rhs) != .orderedDescending
     }
 }
 
-public func >=(lhs: NSNumber, rhs: NSNumber) -> Bool {
-    
+func >=(lhs: NSNumber, rhs: NSNumber) -> Bool {
+
     switch (lhs.isBool, rhs.isBool) {
     case (false, true):
         return false
     case (true, false):
         return false
     default:
-        return lhs.compare(rhs) != NSComparisonResult.OrderedAscending
+        return lhs.compare(rhs) != .orderedAscending
     }
+}
+
+public enum writtingOptionsKeys {
+	case jsonSerialization
+	case castNilToNSNull
+	case maxObjextDepth
+	case encoding
 }

--- a/SwiftRadio/NothingFoundCell.xib
+++ b/SwiftRadio/NothingFoundCell.xib
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="15A284" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -16,15 +20,13 @@
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Loading Stations..." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nc3-Ld-cfB">
                         <rect key="frame" x="85" y="31" width="151" height="25"/>
-                        <animations/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="18"/>
-                        <color key="textColor" red="0.8784313725490196" green="0.8784313725490196" blue="0.8784313725490196" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="textColor" red="0.84939253330230713" green="0.84936714172363281" blue="0.84938156604766846" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
-                <animations/>
             </tableViewCellContentView>
-            <animations/>
             <point key="canvasLocation" x="299" y="254"/>
         </tableViewCell>
     </objects>

--- a/SwiftRadio/NowPlayingViewController.swift
+++ b/SwiftRadio/NowPlayingViewController.swift
@@ -25,7 +25,7 @@ protocol NowPlayingViewControllerDelegate: class {
 //*****************************************************************
 
 class NowPlayingViewController: UIViewController {
-
+    
     @IBOutlet weak var albumHeightConstraint: NSLayoutConstraint!
     @IBOutlet weak var albumImageView: SpringImageView!
     @IBOutlet weak var artistLabel: UILabel!
@@ -60,7 +60,7 @@ class NowPlayingViewController: UIViewController {
         
         // Set AlbumArtwork Constraints
         optimizeForDeviceSize()
-
+        
         // Set View Title
         self.title = currentStation.stationName
         
@@ -72,15 +72,15 @@ class NowPlayingViewController: UIViewController {
         
         // Notification for when app becomes active
         NotificationCenter.default.addObserver(self,
-            selector: #selector(NowPlayingViewController.didBecomeActiveNotificationReceived),
-            name: NSNotification.Name(rawValue: "UIApplicationDidBecomeActiveNotification"),
-            object: nil)
+                                               selector: #selector(NowPlayingViewController.didBecomeActiveNotificationReceived),
+                                               name: NSNotification.Name(rawValue: "UIApplicationDidBecomeActiveNotification"),
+                                               object: nil)
         
         // Notification for AVAudioSession Interruption (e.g. Phone call)
         NotificationCenter.default.addObserver(self,
-            selector: #selector(NowPlayingViewController.sessionInterrupted(_:)),
-            name: NSNotification.Name.AVAudioSessionInterruption,
-            object: AVAudioSession.sharedInstance())
+                                               selector: #selector(NowPlayingViewController.sessionInterrupted(_:)),
+                                               name: NSNotification.Name.AVAudioSessionInterruption,
+                                               object: AVAudioSession.sharedInstance())
         
         // Check for station change
         if newStation {
@@ -137,7 +137,7 @@ class NowPlayingViewController: UIViewController {
             NotificationCenter.default.removeObserver(self, name: NSNotification.Name.AVPlayerItemDidPlayToEndTime, object: self.radioPlayer.currentItem)
         }
     }
-  
+    
     func setupVolumeSlider() {
         // Note: This slider implementation uses a MPVolumeView
         // The volume slider only works in devices, not the simulator.
@@ -145,7 +145,7 @@ class NowPlayingViewController: UIViewController {
         let volumeView = MPVolumeView(frame: volumeParentView.bounds)
         for view in volumeView.subviews {
             let uiview: UIView = view as UIView
-             if (uiview.description as NSString).range(of: "MPVolumeSlider").location != NSNotFound {
+            if (uiview.description as NSString).range(of: "MPVolumeSlider").location != NSNotFound {
                 mpVolumeSlider = (uiview as! UISlider)
             }
         }
@@ -227,7 +227,6 @@ class NowPlayingViewController: UIViewController {
     //*****************************************************************
     
     func optimizeForDeviceSize() {
-        
         // Adjust album size to fit iPhone 4s, 6s & 6s+
         let deviceHeight = self.view.bounds.height
         
@@ -245,7 +244,6 @@ class NowPlayingViewController: UIViewController {
     }
     
     func updateLabels(_ statusMessage: String = "") {
-        
         if statusMessage != "" {
             // There's a an interruption or pause in the audio queue
             songLabel.text = statusMessage
@@ -338,13 +336,13 @@ class NowPlayingViewController: UIViewController {
                     
                     // Turn off network activity indicator
                     UIApplication.shared.isNetworkActivityIndicatorVisible = false
-                        
+                    
                     // Animate artwork
                     self.albumImageView.animation = "wobble"
                     self.albumImageView.duration = 2
                     self.albumImageView.animate()
                     self.stationDescLabel.isHidden = true
-
+                    
                     // Update lockscreen
                     self.updateLockScreen()
                     
@@ -377,25 +375,23 @@ class NowPlayingViewController: UIViewController {
         // Force app to update display
         self.view.setNeedsDisplay()
     }
-
+    
     // Call LastFM or iTunes API to get album art url
     
     func queryAlbumArt() {
-        
         UIApplication.shared.isNetworkActivityIndicatorVisible = true
-        
         // Construct either LastFM or iTunes API call URL
         let queryURL: String
         
         switch coverApi {
-            case .lastFm:
-                queryURL = String(format: "http://ws.audioscrobbler.com/2.0/?method=track.getInfo&api_key=%@&artist=%@&track=%@&format=json", lastFmApiKey, track.artist, track.title)
-                break
-            case .iTunes:
-                queryURL = String(format: "https://itunes.apple.com/search?term=%@+%@&entity=song", track.artist, track.title)
-                break
-            case .spotify:
-                queryURL = String(format: "https://api.spotify.com/v1/search?query=%@+%@&offset=0&limit=20&type=track", track.artist, track.title)
+        case .lastFm:
+            queryURL = String(format: "http://ws.audioscrobbler.com/2.0/?method=track.getInfo&api_key=%@&artist=%@&track=%@&format=json", lastFmApiKey, track.artist, track.title)
+            break
+        case .iTunes:
+            queryURL = String(format: "https://itunes.apple.com/search?term=%@+%@&entity=song", track.artist, track.title)
+            break
+        case .spotify:
+            queryURL = String(format: "https://api.spotify.com/v1/search?query=%@+%@&offset=0&limit=20&type=track", track.artist, track.title)
             break
         }
         
@@ -403,7 +399,6 @@ class NowPlayingViewController: UIViewController {
         
         // Query API
         DataManager.getTrackDataWithSuccess(escapedURL!) { (data) in
-            
             if kDebugLog {
                 print("API SUCCESSFUL RETURN")
                 print("url: \(escapedURL!)")
@@ -477,7 +472,6 @@ class NowPlayingViewController: UIViewController {
     //*****************************************************************
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        
         if segue.identifier == "InfoDetail" {
             let infoController = segue.destination as! InfoDetailViewController
             infoController.currentStation = currentStation
@@ -499,7 +493,6 @@ class NowPlayingViewController: UIViewController {
     //*****************************************************************
     
     func updateLockScreen() {
-        
         // Update notification/lock screen
         let albumArtwork = MPMediaItemArtwork(image: track.artworkImage!)
         
@@ -535,7 +528,6 @@ class NowPlayingViewController: UIViewController {
         }
     }
     
-    
     //*****************************************************************
     // MARK: - AVAudio Sesssion Interrupted
     //*****************************************************************
@@ -546,7 +538,7 @@ class NowPlayingViewController: UIViewController {
             if let type = AVAudioSessionInterruptionType(rawValue: typeValue.uintValue){
                 if type == .began {
                     if kDebugLog {
-                    print("interruption: began")
+                        print("interruption: began")
                     }
                     // Add your code here
                 } else{
@@ -593,17 +585,13 @@ class NowPlayingViewController: UIViewController {
     }
 }
 
-
 //*****************************************************************
 // MARK: - AVPlayerItem Delegate (for metadata)
 //*****************************************************************
 
 extension NowPlayingViewController: CustomAVPlayerItemDelegate {
     func onMetaData(_ metaData: [AVMetadataItem]?) {
-        
-        
         if let metaDatas = metaData{
-            
             startNowPlayingAnimation()
             let firstMeta: AVMetadataItem = metaDatas.first!
             let metaData = firstMeta.value as! String
@@ -620,7 +608,7 @@ extension NowPlayingViewController: CustomAVPlayerItemDelegate {
             track.title = stringParts[0].decodeAllChars()
             
             if stringParts.count > 1 {
-                track.title = stringParts[1].decodeAllChars()
+                
             }
             
             if track.artist == "" && track.title == "" {
@@ -629,37 +617,33 @@ extension NowPlayingViewController: CustomAVPlayerItemDelegate {
             }
             
             DispatchQueue.main.async {
-                
                 if currentSongName != self.track.title {
-                    
                     if kDebugLog {
                         print("METADATA artist: \(self.track.artist) | title: \(self.track.title)")
                     }
-                    
                     // Update Labels
                     self.artistLabel.text = self.track.artist
                     self.songLabel.text = self.track.title
                     self.updateUserActivityState(self.userActivity!)
                     
-                     // songLabel animation
-                     self.songLabel.animation = "zoomIn"
-                     self.songLabel.duration = 1.5
-                     self.songLabel.damping = 1
-                     self.songLabel.animate()
-                     
-                     // Update Stations Screen
-                     self.delegate?.songMetaDataDidUpdate(self.track)
+                    // songLabel animation
+                    self.songLabel.animation = "zoomIn"
+                    self.songLabel.duration = 1.5
+                    self.songLabel.damping = 1
+                    self.songLabel.animate()
+                    
+                    // Update Stations Screen
+                    self.delegate?.songMetaDataDidUpdate(self.track)
                     
                     // Query API for album art
                     self.resetAlbumArtwork()
                     self.queryAlbumArt()
                     
                 }
+                self.artistLabel.text = self.track.artist
+                self.songLabel.text = self.track.title
+
             }
         }
     }
 }
-
-
-
-

--- a/SwiftRadio/NowPlayingViewController.swift
+++ b/SwiftRadio/NowPlayingViewController.swift
@@ -604,11 +604,11 @@ extension NowPlayingViewController: CustomAVPlayerItemDelegate {
             
             // Set artist & songvariables
             let currentSongName = track.title
-            track.artist = stringParts[0].decodeAllChars()
-            track.title = stringParts[0].decodeAllChars()
+            track.artist = stringParts[0].decodeAll()
+            track.title = stringParts[0].decodeAll()
             
             if stringParts.count > 1 {
-                
+                track.title = stringParts[1].decodeAll()
             }
             
             if track.artist == "" && track.title == "" {

--- a/SwiftRadio/PopUpMenuViewController.swift
+++ b/SwiftRadio/PopUpMenuViewController.swift
@@ -15,7 +15,7 @@ class PopUpMenuViewController: UIViewController {
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        modalPresentationStyle = .Custom
+        modalPresentationStyle = .custom
     }
     
     //*****************************************************************
@@ -29,11 +29,11 @@ class PopUpMenuViewController: UIViewController {
         popupView.layer.cornerRadius = 10
         
         // Set background color to clear
-        view.backgroundColor = UIColor.clearColor()
+        view.backgroundColor = UIColor.clear
         
         // Add gesture recognizer to dismiss view when touched
         let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(PopUpMenuViewController.closeButtonPressed))
-        backgroundView.userInteractionEnabled = true
+        backgroundView.isUserInteractionEnabled = true
         backgroundView.addGestureRecognizer(gestureRecognizer)
     }
     
@@ -42,13 +42,13 @@ class PopUpMenuViewController: UIViewController {
     //*****************************************************************
 
     @IBAction func closeButtonPressed() {
-        dismissViewControllerAnimated(true, completion: nil)
+        dismiss(animated: true, completion: nil)
     }
    
-    @IBAction func websiteButtonPressed(sender: UIButton) {
+    @IBAction func websiteButtonPressed(_ sender: UIButton) {
         // Use your own website URL here
-        if let url = NSURL(string: "https://github.com/swiftcodex/") {
-            UIApplication.sharedApplication().openURL(url)
+        if let url = URL(string: "https://github.com/swiftcodex/") {
+            UIApplication.shared.openURL(url)
         }
     }
     

--- a/SwiftRadio/RadioStation.swift
+++ b/SwiftRadio/RadioStation.swift
@@ -40,7 +40,7 @@ class RadioStation: NSObject {
     // MARK: - JSON Parsing into object
     //*****************************************************************
     
-    class func parseStation(stationJSON: JSON) -> (RadioStation) {
+    class func parseStation(_ stationJSON: JSON) -> (RadioStation) {
         
         let name      = stationJSON["name"].string ?? ""
         let streamURL = stationJSON["streamURL"].string ?? ""

--- a/SwiftRadio/StationTableViewCell.swift
+++ b/SwiftRadio/StationTableViewCell.swift
@@ -14,7 +14,7 @@ class StationTableViewCell: UITableViewCell {
     @IBOutlet weak var stationDescLabel: UILabel!
     @IBOutlet weak var stationImageView: UIImageView!
     
-    var downloadTask: NSURLSessionDownloadTask?
+    var downloadTask: URLSessionDownloadTask?
     
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -25,7 +25,7 @@ class StationTableViewCell: UITableViewCell {
         selectedBackgroundView  = selectedView
     }
 
-    func configureStationCell(station: RadioStation) {
+    func configureStationCell(_ station: RadioStation) {
         
         // Configure the cell...
         stationNameLabel.text = station.stationName
@@ -33,9 +33,9 @@ class StationTableViewCell: UITableViewCell {
         
         let imageURL = station.stationImageURL as NSString
         
-            if imageURL.containsString("http") {
+            if imageURL.contains("http") {
             
-            if let url = NSURL(string: station.stationImageURL) {
+            if let url = URL(string: station.stationImageURL) {
                 downloadTask = stationImageView.loadImageWithURL(url) { (image) in
                     // station image loaded
                 }

--- a/SwiftRadio/StationsViewController.swift
+++ b/SwiftRadio/StationsViewController.swift
@@ -295,7 +295,7 @@ extension StationsViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         
-        tableView.deselectRow(at: indexPath, animated: true)
+        firstTime = false
         
         if !stations.isEmpty {
             // Set Now Playing Buttons
@@ -303,9 +303,6 @@ extension StationsViewController: UITableViewDelegate {
             stationNowPlayingButton.setTitle(title, for: UIControlState())
             stationNowPlayingButton.isEnabled = true
         }
-
-        self.title = ""
-        firstTime = false
         
         var nowPlayingVC = self.storyboard!.instantiateViewController(withIdentifier: "NowPlayingViewController") as! NowPlayingViewController
         nowPlayingVC.delegate = self
@@ -327,15 +324,9 @@ extension StationsViewController: UITableViewDelegate {
             
         } else {
             // User clicked on a now playing button
-            if let currentTrack = currentTrack {
-                // Return to NowPlaying controller without reloading station
-                nowPlayingVC.track = currentTrack
-                nowPlayingVC.currentStation = currentStation
-                nowPlayingVC.newStation = false
-                
+            if currentTrack != nil {
                 nowPlayingVC = controllersDict["NowPlayingViewController"] as! NowPlayingViewController!
                 self.navigationController!.pushViewController(nowPlayingVC, animated: true)
-
             } else {
                 // Issue with track, reload station
                 nowPlayingVC.currentStation = currentStation
@@ -347,6 +338,8 @@ extension StationsViewController: UITableViewDelegate {
                 self.navigationController!.pushViewController(nowPlayingVC, animated: true)
             }
         }
+        
+        tableView.deselectRow(at: indexPath, animated: true)
     }
 }
 

--- a/SwiftRadio/StationsViewController.swift
+++ b/SwiftRadio/StationsViewController.swift
@@ -297,6 +297,13 @@ extension StationsViewController: UITableViewDelegate {
         
         tableView.deselectRow(at: indexPath, animated: true)
         
+        if !stations.isEmpty {
+            // Set Now Playing Buttons
+            let title = stations[indexPath.row].stationName + " - Now Playing..."
+            stationNowPlayingButton.setTitle(title, for: UIControlState())
+            stationNowPlayingButton.isEnabled = true
+        }
+
         self.title = ""
         firstTime = false
         
@@ -340,14 +347,6 @@ extension StationsViewController: UITableViewDelegate {
                 self.navigationController!.pushViewController(nowPlayingVC, animated: true)
             }
         }
-
-        if !stations.isEmpty {
-            // Set Now Playing Buttons
-            let title = stations[indexPath.row].stationName + " - Now Playing..."
-            stationNowPlayingButton.setTitle(title, for: UIControlState())
-            stationNowPlayingButton.isEnabled = true
-        }
-        
     }
 }
 

--- a/SwiftRadio/StationsViewController.swift
+++ b/SwiftRadio/StationsViewController.swift
@@ -34,17 +34,15 @@ class StationsViewController: UIViewController {
         
         // Register 'Nothing Found' cell xib
         let cellNib = UINib(nibName: "NothingFoundCell", bundle: nil)
-        tableView.registerNib(cellNib, forCellReuseIdentifier: "NothingFound")
-        
-        preferredStatusBarStyle()
-        
+        tableView.register(cellNib, forCellReuseIdentifier: "NothingFound")
+                
         // Load Data
         loadStationsFromJSON()
         
         // Setup TableView
-        tableView.backgroundColor = UIColor.clearColor()
+        tableView.backgroundColor = UIColor.clear
         tableView.backgroundView = nil
-        tableView.separatorStyle = UITableViewCellSeparatorStyle.None
+        tableView.separatorStyle = UITableViewCellSeparatorStyle.none
         
         // Setup Pull to Refresh
         setupPullToRefresh()
@@ -77,7 +75,7 @@ class StationsViewController: UIViewController {
         setupSearchController()
     }
     
-    override func viewWillAppear(animated: Bool) {
+    override func viewWillAppear(_ animated: Bool) {
         self.title = "Swift Radio"
         
         // If a station has been selected, create "Now Playing" button to get back to current station
@@ -88,7 +86,7 @@ class StationsViewController: UIViewController {
         // If a track is playing, display title & artist information and animation
         if currentTrack != nil && currentTrack!.isPlaying {
             let title = currentStation!.stationName + ": " + currentTrack!.title + " - " + currentTrack!.artist + "..."
-            stationNowPlayingButton.setTitle(title, forState: .Normal)
+            stationNowPlayingButton.setTitle(title, for: UIControlState())
             nowPlayingAnimationImageView.startAnimating()
         } else {
             nowPlayingAnimationImageView.stopAnimating()
@@ -103,10 +101,10 @@ class StationsViewController: UIViewController {
     
     func setupPullToRefresh() {
         self.refreshControl = UIRefreshControl()
-        self.refreshControl.attributedTitle = NSAttributedString(string: "Pull to refresh", attributes: [NSForegroundColorAttributeName:UIColor.whiteColor()])
-        self.refreshControl.backgroundColor = UIColor.blackColor()
-        self.refreshControl.tintColor = UIColor.whiteColor()
-        self.refreshControl.addTarget(self, action: #selector(StationsViewController.refresh(_:)), forControlEvents: UIControlEvents.ValueChanged)
+        self.refreshControl.attributedTitle = NSAttributedString(string: "Pull to refresh", attributes: [NSForegroundColorAttributeName:UIColor.white])
+        self.refreshControl.backgroundColor = UIColor.black
+        self.refreshControl.tintColor = UIColor.white
+        self.refreshControl.addTarget(self, action: #selector(StationsViewController.refresh(_:)), for: UIControlEvents.valueChanged)
         self.tableView.addSubview(refreshControl)
     }
     
@@ -117,7 +115,7 @@ class StationsViewController: UIViewController {
     
     func createNowPlayingBarButton() {
         if self.navigationItem.rightBarButtonItem == nil {
-            let btn = UIBarButtonItem(title: "", style: UIBarButtonItemStyle.Plain, target: self, action:#selector(StationsViewController.nowPlayingBarButtonPressed))
+            let btn = UIBarButtonItem(title: "", style: UIBarButtonItemStyle.plain, target: self, action:#selector(StationsViewController.nowPlayingBarButtonPressed))
             btn.image = UIImage(named: "btn-nowPlaying")
             self.navigationItem.rightBarButtonItem = btn
         }
@@ -134,20 +132,20 @@ class StationsViewController: UIViewController {
             
             // Add UISearchController to the tableView
             tableView.tableHeaderView = searchController?.searchBar
-            tableView.tableHeaderView?.backgroundColor = UIColor.clearColor()
+            tableView.tableHeaderView?.backgroundColor = UIColor.clear
             definesPresentationContext = true
             searchController.hidesNavigationBarDuringPresentation = false
             
             // Style the UISearchController
-            searchController.searchBar.barTintColor = UIColor.clearColor()
-            searchController.searchBar.tintColor = UIColor.whiteColor()
+            searchController.searchBar.barTintColor = UIColor.clear
+            searchController.searchBar.tintColor = UIColor.white
             
             // Hide the UISearchController
             tableView.setContentOffset(CGPoint(x: 0.0, y: searchController.searchBar.frame.size.height), animated: false)
             
             // Set a black keyborad for UISearchController's TextField
-            let searchTextField = searchController.searchBar.valueForKey("_searchField") as! UITextField
-            searchTextField.keyboardAppearance = UIKeyboardAppearance.Dark
+            let searchTextField = searchController.searchBar.value(forKey: "_searchField") as! UITextField
+            searchTextField.keyboardAppearance = UIKeyboardAppearance.dark
         }
 
     }
@@ -157,21 +155,21 @@ class StationsViewController: UIViewController {
     //*****************************************************************
     
     func nowPlayingBarButtonPressed() {
-        performSegueWithIdentifier("NowPlaying", sender: self)
+        performSegue(withIdentifier: "NowPlaying", sender: self)
     }
     
-    @IBAction func nowPlayingPressed(sender: UIButton) {
-        performSegueWithIdentifier("NowPlaying", sender: self)
+    @IBAction func nowPlayingPressed(_ sender: UIButton) {
+        performSegue(withIdentifier: "NowPlaying", sender: self)
     }
     
-    func refresh(sender: AnyObject) {
+    func refresh(_ sender: AnyObject) {
         // Pull to Refresh
-        stations.removeAll(keepCapacity: false)
+        stations.removeAll(keepingCapacity: false)
         loadStationsFromJSON()
         
         // Wait 2 seconds then refresh screen
-        let popTime = dispatch_time(DISPATCH_TIME_NOW, Int64(2 * Double(NSEC_PER_SEC)));
-        dispatch_after(popTime, dispatch_get_main_queue()) { () -> Void in
+        let popTime = DispatchTime.now() + Double(Int64(2 * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC);
+        DispatchQueue.main.asyncAfter(deadline: popTime) { () -> Void in
             self.refreshControl.endRefreshing()
             self.view.setNeedsDisplay()
         }
@@ -184,14 +182,14 @@ class StationsViewController: UIViewController {
     func loadStationsFromJSON() {
         
         // Turn on network indicator in status bar
-        UIApplication.sharedApplication().networkActivityIndicatorVisible = true
+        UIApplication.shared.isNetworkActivityIndicatorVisible = true
         
         // Get the Radio Stations
         DataManager.getStationDataWithSuccess() { (data) in
             
             if kDebugLog { print("Stations JSON Found") }
             
-            let json = JSON(data: data)
+            let json = JSON(data: data!)
             
             if let stationArray = json["station"].array {
                 
@@ -201,7 +199,7 @@ class StationsViewController: UIViewController {
                 }
                 
                 // stations array populated, update table on main queue
-                dispatch_async(dispatch_get_main_queue()) {
+                DispatchQueue.main.async {
                     self.tableView.reloadData()
                     self.view.setNeedsDisplay()
                 }
@@ -211,7 +209,7 @@ class StationsViewController: UIViewController {
             }
             
             // Turn off network indicator in status bar
-            UIApplication.sharedApplication().networkActivityIndicatorVisible = false
+            UIApplication.shared.isNetworkActivityIndicatorVisible = false
         }
     }
     
@@ -219,18 +217,18 @@ class StationsViewController: UIViewController {
     // MARK: - Segue
     //*****************************************************************
     
-    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "NowPlaying" {
             
             self.title = ""
             firstTime = false
             
-            let nowPlayingVC = segue.destinationViewController as! NowPlayingViewController
+            let nowPlayingVC = segue.destination as! NowPlayingViewController
             nowPlayingVC.delegate = self
             
-            if let indexPath = (sender as? NSIndexPath) {
+            if let indexPath = (sender as? IndexPath) {
                 // User clicked on row, load/reset station
-                if searchController.active {
+                if searchController.isActive {
                     currentStation = searchedStations[indexPath.row]
                 } else {
                     currentStation = stations[indexPath.row]
@@ -262,18 +260,18 @@ class StationsViewController: UIViewController {
 extension StationsViewController: UITableViewDataSource {
     
     // MARK: - Table view data source
-    func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 88
     }
     
-    func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+    func numberOfSections(in tableView: UITableView) -> Int {
         return 1
     }
     
-    func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         
         // The UISeachController is active
-        if searchController.active {
+        if searchController.isActive {
             return searchedStations.count
             
         // The UISeachController is not active
@@ -286,22 +284,22 @@ extension StationsViewController: UITableViewDataSource {
         }
     }
     
-    func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         
         if stations.isEmpty {
-            let cell = tableView.dequeueReusableCellWithIdentifier("NothingFound", forIndexPath: indexPath) 
-            cell.backgroundColor = UIColor.clearColor()
-            cell.selectionStyle = UITableViewCellSelectionStyle.None
+            let cell = tableView.dequeueReusableCell(withIdentifier: "NothingFound", for: indexPath) 
+            cell.backgroundColor = UIColor.clear
+            cell.selectionStyle = UITableViewCellSelectionStyle.none
             return cell
             
         } else {
-            let cell = tableView.dequeueReusableCellWithIdentifier("StationCell", forIndexPath: indexPath) as! StationTableViewCell
+            let cell = tableView.dequeueReusableCell(withIdentifier: "StationCell", for: indexPath) as! StationTableViewCell
             
             // alternate background color
             if indexPath.row % 2 == 0 {
-                cell.backgroundColor = UIColor.clearColor()
+                cell.backgroundColor = UIColor.clear
             } else {
-                cell.backgroundColor = UIColor.blackColor().colorWithAlphaComponent(0.2)
+                cell.backgroundColor = UIColor.black.withAlphaComponent(0.2)
             }
             
             // Configure the cell...
@@ -309,7 +307,7 @@ extension StationsViewController: UITableViewDataSource {
             cell.configureStationCell(station)
             
             // The UISeachController is active
-            if searchController.active {
+            if searchController.isActive {
                 let station = searchedStations[indexPath.row]
                 cell.configureStationCell(station)
                 
@@ -330,18 +328,18 @@ extension StationsViewController: UITableViewDataSource {
 
 extension StationsViewController: UITableViewDelegate {
     
-    func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         
-        tableView.deselectRowAtIndexPath(indexPath, animated: true)
+        tableView.deselectRow(at: indexPath, animated: true)
         
         if !stations.isEmpty {
             
             // Set Now Playing Buttons
             let title = stations[indexPath.row].stationName + " - Now Playing..."
-            stationNowPlayingButton.setTitle(title, forState: .Normal)
-            stationNowPlayingButton.enabled = true
+            stationNowPlayingButton.setTitle(title, for: UIControlState())
+            stationNowPlayingButton.isEnabled = true
             
-            performSegueWithIdentifier("NowPlaying", sender: indexPath)
+            performSegue(withIdentifier: "NowPlaying", sender: indexPath)
         }
     }
 }
@@ -352,18 +350,18 @@ extension StationsViewController: UITableViewDelegate {
 
 extension StationsViewController: NowPlayingViewControllerDelegate {
     
-    func artworkDidUpdate(track: Track) {
+    func artworkDidUpdate(_ track: Track) {
         currentTrack?.artworkURL = track.artworkURL
         currentTrack?.artworkImage = track.artworkImage
     }
     
-    func songMetaDataDidUpdate(track: Track) {
+    func songMetaDataDidUpdate(_ track: Track) {
         currentTrack = track
         let title = currentStation!.stationName + ": " + currentTrack!.title + " - " + currentTrack!.artist + "..."
-        stationNowPlayingButton.setTitle(title, forState: .Normal)
+        stationNowPlayingButton.setTitle(title, for: UIControlState())
     }
     
-    func trackPlayingToggled(track: Track) {
+    func trackPlayingToggled(_ track: Track) {
         currentTrack?.isPlaying = track.isPlaying
     }
 
@@ -375,16 +373,16 @@ extension StationsViewController: NowPlayingViewControllerDelegate {
 
 extension StationsViewController: UISearchResultsUpdating {
 
-    func updateSearchResultsForSearchController(searchController: UISearchController) {
+    func updateSearchResults(for searchController: UISearchController) {
     
         // Empty the searchedStations array
-        searchedStations.removeAll(keepCapacity: false)
+        searchedStations.removeAll(keepingCapacity: false)
     
         // Create a Predicate
         let searchPredicate = NSPredicate(format: "SELF.stationName CONTAINS[c] %@", searchController.searchBar.text!)
     
         // Create an NSArray with a Predicate
-        let array = (self.stations as NSArray).filteredArrayUsingPredicate(searchPredicate)
+        let array = (self.stations as NSArray).filtered(using: searchPredicate)
     
         // Set the searchedStations with search result array
         searchedStations = array as! [RadioStation]

--- a/SwiftRadio/UIImage+DropShadow.swift
+++ b/SwiftRadio/UIImage+DropShadow.swift
@@ -13,7 +13,7 @@ extension UIImageView {
     // APPLY DROP SHADOW
     func applyShadow() {
 		let layer           = self.layer
-		layer.shadowColor   = UIColor.blackColor().CGColor
+		layer.shadowColor   = UIColor.black.cgColor
 		layer.shadowOffset  = CGSize(width: 0, height: 1)
 		layer.shadowOpacity = 0.4
 		layer.shadowRadius  = 2

--- a/SwiftRadio/UIImageView+Download.swift
+++ b/SwiftRadio/UIImageView+Download.swift
@@ -10,17 +10,17 @@ import UIKit
 
 extension UIImageView {
     
-    func loadImageWithURL(url: NSURL, callback:(UIImage) -> ()) -> NSURLSessionDownloadTask {
-        let session = NSURLSession.sharedSession()
+    func loadImageWithURL(_ url: URL, callback:@escaping (UIImage) -> ()) -> URLSessionDownloadTask {
+        let session = URLSession.shared
         
-        let downloadTask = session.downloadTaskWithURL(url, completionHandler: {
+        let downloadTask = session.downloadTask(with: url, completionHandler: {
             [weak self] url, response, error in
             
             if error == nil && url != nil {
-                if let data = NSData(contentsOfURL: url!) {
+                if let data = try? Data(contentsOf: url!) {
                     if let image = UIImage(data: data) {
                         
-                        dispatch_async(dispatch_get_main_queue()) {
+                        DispatchQueue.main.async {
                             
                             if let strongSelf = self {
                                 strongSelf.image = image

--- a/SwiftRadio/stations.json
+++ b/SwiftRadio/stations.json
@@ -9,25 +9,11 @@
      "longDesc": "Sub Pop is a record label founded in 1986 by Bruce Pavitt. In 1988, Sub Pop Records LLC was formed by Bruce Pavitt and Jonathan Poneman in Seattle, Washington. Sub Pop achieved fame in the late 1980s for first signing Nirvana, Soundgarden, Mudhoney and many other bands from the Seattle alternative rock scene."
      },
      {
-     "name": "Sounds of the 80s",
-     "streamURL": "http://tuneinads.moodmedia.com/streams/tunein_sounds_of_the_80s_with_ads.mp3",
-     "imageURL": "station-80s",
-     "desc": "Totally Rad",
-     "longDesc": "80s Baby! The '80s is not about nostalgia; it is about a decade of people, decisions and inventions that changed our future, told from the perspective of unknowing history makers who lived these iconic moments."
-     },
-     {
      "name": "Clasic Rock",
      "streamURL": "http://rfcmedia.streamguys1.com/classicrock.mp3",
      "imageURL": "station-classicrock",
      "desc": "Classic Rock Hits",
      "longDesc": "Classic rock is a radio format which developed from the album-oriented rock (AOR) format in the early 1980s. In the United States, the classic rock format features music ranging generally from the late 1960s to the late 1980s, primarily focusing on commercially successful hard rock popularized in the 1970s. The radio format became increasingly popular with the baby boomer demographic by the end of the 1990s."
-     },
-     {
-     "name": "Radio 1190",
-     "streamURL": "http://radio1190.colorado.edu:8000/high.mp3",
-     "imageURL": "",
-     "desc": "KVCU - Boulder, CO",
-     "longDesc": "Radio 1190 is the bomb."
      }
     ]
 }

--- a/SwiftRadioUITests/SwiftRadioUITests.swift
+++ b/SwiftRadioUITests/SwiftRadioUITests.swift
@@ -15,7 +15,7 @@ class SwiftRadioUITests: XCTestCase {
     let hamburgerMenu = XCUIApplication().navigationBars["Swift Radio"].buttons["icon hamburger"]
     let pauseButton = XCUIApplication().buttons["btn pause"]
     let playButton = XCUIApplication().buttons["btn play"]
-    let volume = XCUIApplication().sliders.elementBoundByIndex(0)
+    let volume = XCUIApplication().sliders.element(boundBy: 0)
     
     override func setUp() {
         super.setUp()
@@ -28,11 +28,11 @@ class SwiftRadioUITests: XCTestCase {
         XCUIApplication().launch()
 
         // wait for the main view to load
-        self.expectationForPredicate(
-            NSPredicate(format: "self.count > 0"),
-            evaluatedWithObject: stations,
+        self.expectation(
+            for: NSPredicate(format: "self.count > 0"),
+            evaluatedWith: stations,
             handler: nil)
-        self.waitForExpectationsWithTimeout(10.0, handler: nil)
+        self.waitForExpectations(timeout: 10.0, handler: nil)
         
         // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
     }
@@ -60,41 +60,41 @@ class SwiftRadioUITests: XCTestCase {
     }
     
     func assertPaused() {
-        XCTAssertFalse(pauseButton.enabled)
-        XCTAssertTrue(playButton.enabled)
+        XCTAssertFalse(pauseButton.isEnabled)
+        XCTAssertTrue(playButton.isEnabled)
         XCTAssertTrue(app.staticTexts["Station Paused..."].exists);
     }
     
     func assertPlaying() {
-        XCTAssertTrue(pauseButton.enabled)
-        XCTAssertFalse(playButton.enabled)
+        XCTAssertTrue(pauseButton.isEnabled)
+        XCTAssertFalse(playButton.isEnabled)
         XCTAssertFalse(app.staticTexts["Station Paused..."].exists);
     }
     
-    func assertStationOnMenu(stationName:String) {
+    func assertStationOnMenu(_ stationName:String) {
         let button = app.buttons["nowPlaying"];
         if let value:String = button.label {
-            XCTAssertTrue(value.containsString(stationName))
+            XCTAssertTrue(value.contains(stationName))
         } else {
             XCTAssertTrue(false)
         }
     }
     
     func assertStationInfo() {
-        let textView = app.textViews.elementBoundByIndex(0)
+        let textView = app.textViews.element(boundBy: 0)
         if let value = textView.value {
-            XCTAssertGreaterThan(value.length, 10)
+            XCTAssertGreaterThan((value as AnyObject).length, 10)
         } else {
             XCTAssertTrue(false)
         }
     }
     
     func waitForStationToLoad() {
-        self.expectationForPredicate(
-            NSPredicate(format: "exists == 0"),
-            evaluatedWithObject: app.staticTexts["Loading Station..."],
+        self.expectation(
+            for: NSPredicate(format: "exists == 0"),
+            evaluatedWith: app.staticTexts["Loading Station..."],
             handler: nil)
-        self.waitForExpectationsWithTimeout(25.0, handler: nil)
+        self.waitForExpectations(timeout: 25.0, handler: nil)
 
     }
     
@@ -112,8 +112,8 @@ class SwiftRadioUITests: XCTestCase {
         app.buttons["btn close"].tap()
         assertStationsPresent()
         
-        let firstStation = stations.elementBoundByIndex(0)
-        let stationName:String = firstStation.childrenMatchingType(.StaticText).elementBoundByIndex(0).label
+        let firstStation = stations.element(boundBy: 0)
+        let stationName:String = firstStation.children(matching: .staticText).element(boundBy: 0).label
         assertStationOnMenu("Choose")
         firstStation.tap()
         waitForStationToLoad();
@@ -126,9 +126,9 @@ class SwiftRadioUITests: XCTestCase {
         assertStationOnMenu(stationName)
         app.navigationBars["Swift Radio"].buttons["btn nowPlaying"].tap()
         waitForStationToLoad()
-        volume.adjustToNormalizedSliderPosition(0.2)
-        volume.adjustToNormalizedSliderPosition(0.8)
-        volume.adjustToNormalizedSliderPosition(0.5)
+        volume.adjust(toNormalizedSliderPosition: 0.2)
+        volume.adjust(toNormalizedSliderPosition: 0.8)
+        volume.adjust(toNormalizedSliderPosition: 0.5)
         app.buttons["More Info"].tap()
         assertStationInfo()
         app.buttons["Okay"].tap()


### PR DESCRIPTION
Hi, I really want to thank you for your awesome work, I'm currently working on your branch based on AVPlayer and xCode 8, here my fork: https://github.com/giacmarangoni/Swift-Radio-Pro/tree/xcode8.
First of all, I converted the whole project to current swift version, I updated Spring and SwiftyJSON libraries, I added some string decoding support for latin chars and I removed from JSON broken radio stations. Everything is working fine but I noticed a little bug.
When I open your application for the first time and when I start the player everything is working fine. Song label, artist label and artwork update correctly but, after coming back to the stations screen and returning to now playing view everything is messed up. AVPlayer streams but each label and artwork stops to update.
Normally, when you "go back" from a pushed view controller, the pushed view controller is popped and destroyed. Your pushed view controller is a NowPlayingViewController. It should be destroyed when you "go back" from it to the StationsViewController. Thus, when you show the NowPlayingViewController again, you would have to create a new, different NowPlayingViewController.
Okay, so far so good but in your case there is a further complication: there's a leak. Your old NowPlayingViewController is not being destroyed. Thus, when you "go back" to the StationsViewController and show the NowPlayingViewController for a second time, there are now two NowPlayingViewControllers — the new one that everyone can see, and the old one that is leaking.
So the logging continues to show the old NowPlayingViewController, which is still observing and updating. But we are seeing the new NowPlayingViewController, which is doing nothing. And that explains the phenomena I have described.