### PR TITLE
Headphone clicker support for xcode8 branch

### DIFF
--- a/SwiftRadio/NowPlayingViewController.swift
+++ b/SwiftRadio/NowPlayingViewController.swift
@@ -69,7 +69,6 @@ class NowPlayingViewController: UIViewController {
         
         setUpPlayer()
         
-        
         // Notification for when app becomes active
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(NowPlayingViewController.didBecomeActiveNotificationReceived),
@@ -220,6 +219,14 @@ class NowPlayingViewController: UIViewController {
     
     @IBAction func volumeChanged(_ sender:UISlider) {
         mpVolumeSlider.value = sender.value
+    }
+ 
+    @objc func togglePlayPause() {
+        if track.isPlaying {
+            pausePressed()
+        } else {
+            playPressed()
+        }
     }
     
     //*****************************************************************
@@ -522,6 +529,8 @@ class NowPlayingViewController: UIViewController {
         MPRemoteCommandCenter.shared().playCommand.addTarget(self, action: #selector(playPressed))
         MPRemoteCommandCenter.shared().pauseCommand.isEnabled = true
         MPRemoteCommandCenter.shared().pauseCommand.addTarget(self, action: #selector(pausePressed))
+        MPRemoteCommandCenter.shared().togglePlayPauseCommand.isEnabled = true
+        MPRemoteCommandCenter.shared().togglePlayPauseCommand.addTarget(self, action: #selector(togglePlayPause))
     }
     
     override func remoteControlReceived(with receivedEvent: UIEvent?) {


### PR DESCRIPTION
Adds the MPRemoteCommandCenter.shared().togglePlayPauseCommand support to enable this.