### PR TITLE
Fix a crash when fetching stations & offline

### DIFF
--- a/SwiftRadio/StationsViewController.swift
+++ b/SwiftRadio/StationsViewController.swift
@@ -16,17 +16,17 @@ class StationsViewController: UIViewController {
     @IBOutlet weak var stationNowPlayingButton: UIButton!
     @IBOutlet weak var nowPlayingAnimationImageView: UIImageView!
     
-    @objc var stations = [RadioStation]()
-    @objc var currentStation: RadioStation?
+    var stations = [RadioStation]()
+    var currentStation: RadioStation?
     var currentTrack: Track?
-    @objc var refreshControl: UIRefreshControl!
-    @objc var firstTime = true
+    var refreshControl: UIRefreshControl!
+    var firstTime = true
     
-    @objc var searchedStations = [RadioStation]()
-    @objc var searchController : UISearchController!
+    var searchedStations = [RadioStation]()
+    var searchController : UISearchController!
     
     @objc var controllersDict = [String:Any]()
-    
+
     @objc var lastIndexPath : IndexPath!
     
     //*****************************************************************
@@ -65,7 +65,11 @@ class StationsViewController: UIViewController {
             success = false
         }
         if !success {
-            if kDebugLog { print("Failed to set audio session category.  Error: \(error)") }
+            if kDebugLog {
+                if let e = error {
+                    print("Failed to set audio session category.  Error: \(e)")
+                }
+            }
         }
         
         // Set audioSession as active
@@ -103,7 +107,7 @@ class StationsViewController: UIViewController {
     // MARK: - Setup UI Elements
     //*****************************************************************
     
-    @objc func setupPullToRefresh() {
+    func setupPullToRefresh() {
         self.refreshControl = UIRefreshControl()
         self.refreshControl.attributedTitle = NSAttributedString(string: "Pull to refresh", attributes: [NSAttributedStringKey.foregroundColor:UIColor.white])
         self.refreshControl.backgroundColor = UIColor.black
@@ -112,12 +116,12 @@ class StationsViewController: UIViewController {
         self.tableView.addSubview(refreshControl)
     }
     
-    @objc func createNowPlayingAnimation() {
+    func createNowPlayingAnimation() {
         nowPlayingAnimationImageView.animationImages = AnimationFrames.createFrames()
         nowPlayingAnimationImageView.animationDuration = 0.7
     }
     
-    @objc func createNowPlayingBarButton() {
+    func createNowPlayingBarButton() {
         if self.navigationItem.rightBarButtonItem == nil {
             let btn = UIBarButtonItem(title: "", style: UIBarButtonItemStyle.plain, target: self, action:#selector(StationsViewController.nowPlayingBarButtonPressed))
             btn.image = UIImage(named: "btn-nowPlaying")
@@ -125,7 +129,7 @@ class StationsViewController: UIViewController {
         }
     }
     
-    @objc func setupSearchController() {
+    func setupSearchController() {
         // Set the UISearchController
         searchController = UISearchController(searchResultsController: nil)
         
@@ -183,7 +187,7 @@ class StationsViewController: UIViewController {
     // MARK: - Load Station Data
     //*****************************************************************
     
-    @objc func loadStationsFromJSON() {
+    func loadStationsFromJSON() {
         
         // Turn on network indicator in status bar
         DispatchQueue.main.async {
@@ -314,17 +318,17 @@ extension StationsViewController: UITableViewDelegate {
             // User clicked on row, load/reset station
             if searchController.isActive {
                 currentStation = searchedStations[indexPath.row]
-            } else {
+            } else if stations.count > 0 {
                 currentStation = stations[indexPath.row]
+
+                nowPlayingVC.currentStation = currentStation
+                nowPlayingVC.newStation = true
+
+                lastIndexPath = indexPath
+
+                controllersDict["NowPlayingViewController"] = nowPlayingVC
+                self.navigationController!.pushViewController(nowPlayingVC, animated: true)
             }
-            nowPlayingVC.currentStation = currentStation
-            nowPlayingVC.newStation = true
-            
-            lastIndexPath = indexPath
-            
-            controllersDict["NowPlayingViewController"] = nowPlayingVC
-            self.navigationController!.pushViewController(nowPlayingVC, animated: true)
-            
         } else {
             // User clicked on a now playing button
             if currentTrack != nil {


### PR DESCRIPTION
Scenario:
 - device is offline
 - station JSON is being loaded from a remote file
 - load fails
 - application crashes

 Fix:
  - change the check in StationsViewController to verify that the
    station count is > 0 before trying to update the table view.
    Pull-to-refresh is still enabled, so the app remains responsive
    until the network connection is reestablished and the JSON can be
    downloaded.